### PR TITLE
Adding some Spanish banks and Halifax from UK

### DIFF
--- a/schwifty/bank_registry/manual_es.json
+++ b/schwifty/bank_registry/manual_es.json
@@ -1,0 +1,122 @@
+[
+  {
+    "primary": true,
+    "name": "ING BANK, N.V. SUCURSAL EN ESPAÑA",
+    "short_name": "ING BANK ESPAÑA",
+    "bank_code": "1465",
+    "bic": "INGDESMMXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "BANCO SANTANDER, S.A.",
+    "short_name": "BANCO SANTANDER",
+    "bank_code": "0049",
+    "bic": "BSCHESMM",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "BANCO SANTANDER, S.A.",
+    "short_name": "BANCO SANTANDER",
+    "bank_code": "0075",
+    "bic": "BSCHESMM",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "CAIXABANK, S.A.",
+    "short_name": "CAIXABANK",
+    "bank_code": "2100",
+    "bic": "CAIXESBBXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "BANKINTER, S.A.",
+    "short_name": "BANKINTER",
+    "bank_code": "0128",
+    "bic": "BKBKESMMXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "OPEN BANK, S.A.",
+    "short_name": "OPEN BANK",
+    "bank_code": "0073",
+    "bic": "OPENESMMXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "BANCO DE SABADELL, S.A.",
+    "short_name": "BANCO DE SABADELL",
+    "bank_code": "0081",
+    "bic": "BSABESBBXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "BANCO MEDIOLANUM, S.A.",
+    "short_name": "BANCO MEDIOLANUM",
+    "bank_code": "0186",
+    "bic": "BFIVESBBXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "CAJA RURAL DEL SUR, S. COOP. DE CREDITO",
+    "short_name": "CAJA RURAL DEL SUR",
+    "bank_code": "3187",
+    "bic": "BCOEESMM187",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "EVO BANCO S.A.",
+    "short_name": "EVO BANCO",
+    "bank_code": "0239",
+    "bic": "EVOBESMMXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "EVO BANCO S.A.",
+    "short_name": "EVO BANCO",
+    "bank_code": "0239",
+    "bic": "EVOBESMMXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "BANCO BILBAO VIZCAYA ARGENTARIA, S.A.",
+    "short_name": "BBVA",
+    "bank_code": "0182",
+    "bic": "BBVAESMMXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "KUTXABANK, S.A.",
+    "short_name": "KUTXABANK",
+    "bank_code": "2095",
+    "bic": "BASKES2BXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "CAJA DE CREDITO DE LOS INGENIEROS,  S. COOP. DE CREDITO",
+    "short_name": "CAJA DE CREDITO DE INGENIEROS",
+    "bank_code": "3025",
+    "bic": "CDENESBBXXX",
+    "country_code": "ES"
+  },
+  {
+    "primary": true,
+    "name": "BANKIA, S.A.",
+    "short_name": "BANKIA",
+    "bank_code": "2038",
+    "bic": "CAHMESMMXXX",
+    "country_code": "ES"
+  }
+]

--- a/schwifty/bank_registry/manual_gb.json
+++ b/schwifty/bank_registry/manual_gb.json
@@ -1,0 +1,10 @@
+[
+  {
+    "primary": true,
+    "name": "HALIFAX (A TRADING NAME OF BANK OF SCOTLAND PLC)",
+    "short_name": "HALIFAX",
+    "bank_code": "HLFX",
+    "bic": "HLFXGB21N85",
+    "country_code": "GB"
+  }
+]


### PR DESCRIPTION
This is what I have for now. Added, among others, BBVA, Banco Santander, CaixaBank, Banco Sabadell, and ING.
I'll continue adding more banks as a get more bank accounts to extract the needed info. I'll also work on the new Exceptions as discussed in #19.

I would need this merged and released to use the new banks data in my project. Unless there is an easy way to use a tarball version from my own repo. I used to do so via `dependency_links` but it looks like pbr doesn't play well with that snapshot-like option. What I have done is to tag my update as 2020.01.1 in my repo and setup my `dependency_links` to point to my repo's tarball (`https://github.com/osroca/schwifty/tarball/2020.01.1#egg=schwifty-2020.01.1`). This caused the following error when installing my project:

```
  File "/private/var/folders/z_/ll7j31r11p37z687bk0w7bs80000gn/T/easy_install-id3gs88l/osroca-schwifty-2a88b09/.eggs/pbr-5.4.4-py3.7.egg/pbr/hooks/metadata.py", line 26, in hook
    self.config['name'], self.config.get('version', None))
  File "/private/var/folders/z_/ll7j31r11p37z687bk0w7bs80000gn/T/easy_install-id3gs88l/osroca-schwifty-2a88b09/.eggs/pbr-5.4.4-py3.7.egg/pbr/packaging.py", line 876, in get_version
    name=package_name))
Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name schwifty was given, but was not able to be found.
error: Setup script exited with error in setup command: Error parsing /private/var/folders/z_/ll7j31r11p37z687bk0w7bs80000gn/T/easy_install-id3gs88l/osroca-schwifty-2a88b09/setup.cfg: Exception: Versioning for this project requires either an sdist tarball, or access to an upstream git repository. It's also possible that there is a mismatch between the package name in setup.cfg and the argument given to pbr.version.VersionInfo. Project name schwifty was given, but was not able to be found.
```

It's a bit embarrassing, but I'm not familiar enough to pbr.