### PR TITLE
Add FR, CH & GB banks (+quick fix over FI bics)

### DIFF
--- a/schwifty/bank_registry/generated_fi.json
+++ b/schwifty/bank_registry/generated_fi.json
@@ -1602,7 +1602,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "310",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1610,7 +1610,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "311",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1618,7 +1618,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "312",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1626,7 +1626,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "313",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1634,7 +1634,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "314",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1642,7 +1642,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "315",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1650,7 +1650,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "316",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1658,7 +1658,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "317",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1666,7 +1666,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "318",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1674,7 +1674,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HANDFIHH ",
+    "bic": "HANDFIHH",
     "bank_code": "319",
     "name": "SVENSKA HANDELSBANKEN",
     "short_name": "SVENSKA HANDELSBANKEN"
@@ -1682,7 +1682,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "330",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1690,7 +1690,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "331",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1698,7 +1698,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "332",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1706,7 +1706,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "333",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1714,7 +1714,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "334",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1722,7 +1722,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "335",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1730,7 +1730,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "336",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1738,7 +1738,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "337",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1746,7 +1746,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "338",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1754,7 +1754,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "ESSEFIHX ",
+    "bic": "ESSEFIHX",
     "bank_code": "339",
     "name": "SKANDINAVISKA ENSKILDA BANKEN",
     "short_name": "SKANDINAVISKA ENSKILDA BANKEN"
@@ -1762,7 +1762,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "340",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1770,7 +1770,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "341",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1778,7 +1778,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "342",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1786,7 +1786,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "343",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1794,7 +1794,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "344",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1802,7 +1802,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "345",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1810,7 +1810,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "346",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1818,7 +1818,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "347",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1826,7 +1826,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "348",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1834,7 +1834,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "349",
     "name": "DANSKE BANK A/S, FINLAND BRANCH",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH"
@@ -1922,7 +1922,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "370",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1930,7 +1930,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "371",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1938,7 +1938,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "372",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1946,7 +1946,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "373",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1954,7 +1954,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "374",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1962,7 +1962,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "375",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1970,7 +1970,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "376",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1978,7 +1978,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "377",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1986,7 +1986,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "378",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -1994,7 +1994,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DNBAFIHX ",
+    "bic": "DNBAFIHX",
     "bank_code": "379",
     "name": "DNB NOR BANK ASA, FILIAL FINLAND",
     "short_name": "DNB NOR BANK ASA, FILIAL FINLAND"
@@ -2186,7 +2186,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HELSFIHH ",
+    "bic": "HELSFIHH",
     "bank_code": "405",
     "name": "AKTIA BANK P.L.C.",
     "short_name": "AKTIA BANK P.L.C."
@@ -2802,7 +2802,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "HELSFIHH ",
+    "bic": "HELSFIHH",
     "bank_code": "497",
     "name": "AKTIA BANK P.L.C.",
     "short_name": "AKTIA BANK P.L.C."
@@ -2810,7 +2810,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "500",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2818,7 +2818,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "501",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2826,7 +2826,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "502",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2834,7 +2834,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "503",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2842,7 +2842,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "504",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2850,7 +2850,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "505",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2858,7 +2858,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "506",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2866,7 +2866,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "507",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2874,7 +2874,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "508",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2882,7 +2882,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "509",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2890,7 +2890,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "510",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2898,7 +2898,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "511",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2906,7 +2906,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "512",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2914,7 +2914,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "513",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2922,7 +2922,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "514",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2930,7 +2930,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "515",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2938,7 +2938,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "516",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2946,7 +2946,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "517",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2954,7 +2954,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "518",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2962,7 +2962,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "519",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2970,7 +2970,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "520",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2978,7 +2978,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "521",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2986,7 +2986,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "522",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -2994,7 +2994,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "523",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3002,7 +3002,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "524",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3010,7 +3010,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "525",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3018,7 +3018,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "526",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3026,7 +3026,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "527",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3034,7 +3034,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "528",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3042,7 +3042,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "529",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3050,7 +3050,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "530",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3058,7 +3058,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "531",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3066,7 +3066,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "532",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3074,7 +3074,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "533",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3082,7 +3082,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "534",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3090,7 +3090,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "535",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3098,7 +3098,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "536",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3106,7 +3106,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "537",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3114,7 +3114,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "538",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3122,7 +3122,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "539",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3130,7 +3130,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "540",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3138,7 +3138,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "541",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3146,7 +3146,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "542",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3154,7 +3154,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "543",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3162,7 +3162,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "544",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3170,7 +3170,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "545",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3178,7 +3178,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "546",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3186,7 +3186,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "547",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3194,7 +3194,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "548",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3202,7 +3202,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "549",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3210,7 +3210,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "550",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3218,7 +3218,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "551",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3226,7 +3226,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "552",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3234,7 +3234,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "553",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3242,7 +3242,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "554",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3250,7 +3250,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "555",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3258,7 +3258,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "556",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3266,7 +3266,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "557",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3274,7 +3274,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "558",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3282,7 +3282,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "559",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3290,7 +3290,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "560",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3298,7 +3298,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "561",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3306,7 +3306,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "562",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3314,7 +3314,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "563",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3322,7 +3322,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "564",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3330,7 +3330,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "565",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3338,7 +3338,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "566",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3346,7 +3346,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "567",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3354,7 +3354,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "568",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3362,7 +3362,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "569",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3370,7 +3370,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "570",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3378,7 +3378,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "571",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3386,7 +3386,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "572",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3394,7 +3394,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "573",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3402,7 +3402,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "574",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3410,7 +3410,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "575",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3418,7 +3418,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "576",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3426,7 +3426,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "577",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3434,7 +3434,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "578",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3442,7 +3442,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "579",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3450,7 +3450,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "580",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3458,7 +3458,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "581",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3466,7 +3466,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "582",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3474,7 +3474,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "583",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3482,7 +3482,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "584",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3490,7 +3490,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "585",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3498,7 +3498,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "586",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3506,7 +3506,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "587",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3514,7 +3514,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "588",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3522,7 +3522,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "589",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3530,7 +3530,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "590",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3538,7 +3538,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "591",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3546,7 +3546,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "592",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3554,7 +3554,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "593",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3562,7 +3562,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "594",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3570,7 +3570,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "595",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3578,7 +3578,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "596",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3586,7 +3586,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "597",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3594,7 +3594,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "598",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3602,7 +3602,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "OKOYFIHH ",
+    "bic": "OKOYFIHH",
     "bank_code": "599",
     "name": "OP CORPORATE BANK PLC",
     "short_name": "OP CORPORATE BANK PLC"
@@ -3610,7 +3610,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "600",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3618,7 +3618,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "601",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3626,7 +3626,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "602",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3634,7 +3634,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "603",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3642,7 +3642,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "604",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3650,7 +3650,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "605",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3658,7 +3658,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "606",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3666,7 +3666,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "607",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3674,7 +3674,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "608",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3682,7 +3682,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "609",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3690,7 +3690,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "610",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3698,7 +3698,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "611",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3706,7 +3706,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "612",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3714,7 +3714,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "613",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3722,7 +3722,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "614",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3730,7 +3730,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "615",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3738,7 +3738,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "616",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3746,7 +3746,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "617",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3754,7 +3754,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "618",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3762,7 +3762,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "619",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3770,7 +3770,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "620",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3778,7 +3778,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "621",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3786,7 +3786,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "622",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3794,7 +3794,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "623",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3802,7 +3802,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "624",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3810,7 +3810,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "625",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3818,7 +3818,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "626",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3826,7 +3826,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "627",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3834,7 +3834,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "628",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3842,7 +3842,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "629",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3850,7 +3850,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "630",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3858,7 +3858,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "631",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3866,7 +3866,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "632",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3874,7 +3874,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "633",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3882,7 +3882,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "634",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3890,7 +3890,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "635",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3898,7 +3898,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "636",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3906,7 +3906,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "637",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3914,7 +3914,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "638",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3922,7 +3922,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "639",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3930,7 +3930,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "640",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3938,7 +3938,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "641",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3946,7 +3946,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "642",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3954,7 +3954,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "643",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3962,7 +3962,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "644",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3970,7 +3970,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "645",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3978,7 +3978,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "646",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3986,7 +3986,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "647",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -3994,7 +3994,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "648",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4002,7 +4002,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "649",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4010,7 +4010,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "650",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4018,7 +4018,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "651",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4026,7 +4026,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "652",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4034,7 +4034,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "653",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4042,7 +4042,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "654",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4050,7 +4050,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "655",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4058,7 +4058,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "656",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4066,7 +4066,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "657",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4074,7 +4074,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "658",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4082,7 +4082,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "659",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4090,7 +4090,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "660",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4098,7 +4098,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "661",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4106,7 +4106,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "662",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4114,7 +4114,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "663",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4122,7 +4122,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "664",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4130,7 +4130,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "665",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4138,7 +4138,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "666",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4146,7 +4146,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "667",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4154,7 +4154,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "668",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4162,7 +4162,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "669",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4170,7 +4170,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "660",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4178,7 +4178,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "661",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4186,7 +4186,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "662",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4194,7 +4194,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "663",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4202,7 +4202,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "664",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4210,7 +4210,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "665",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4218,7 +4218,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "666",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4226,7 +4226,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "667",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4234,7 +4234,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "668",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4242,7 +4242,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "669",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4250,7 +4250,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "670",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4258,7 +4258,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "671",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4266,7 +4266,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "672",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4274,7 +4274,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "673",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4282,7 +4282,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "674",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4290,7 +4290,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "675",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4298,7 +4298,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "676",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4306,7 +4306,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "677",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4314,7 +4314,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "678",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4322,7 +4322,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "679",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4330,7 +4330,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "680",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4338,7 +4338,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "681",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4346,7 +4346,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "682",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4354,7 +4354,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "683",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4362,7 +4362,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "684",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4370,7 +4370,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "685",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4378,7 +4378,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "686",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4386,7 +4386,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "687",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4394,7 +4394,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "688",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4402,7 +4402,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "689",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4410,7 +4410,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "690",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4418,7 +4418,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "691",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4426,7 +4426,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "692",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4434,7 +4434,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "693",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4442,7 +4442,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "694",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4450,7 +4450,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "695",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4458,7 +4458,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "696",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4466,7 +4466,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "697",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4474,7 +4474,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "698",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4482,7 +4482,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "AABAFI22 ",
+    "bic": "AABAFI22",
     "bank_code": "699",
     "name": "BANK OF ALAND PLC",
     "short_name": "BANK OF ALAND PLC"
@@ -4522,7 +4522,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "800",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4530,7 +4530,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "801",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4538,7 +4538,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "802",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4546,7 +4546,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "803",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4554,7 +4554,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "804",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4562,7 +4562,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "805",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4570,7 +4570,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "806",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4578,7 +4578,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "807",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4586,7 +4586,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "808",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4594,7 +4594,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "809",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4602,7 +4602,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "810",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4610,7 +4610,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "811",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4618,7 +4618,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "812",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4626,7 +4626,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "813",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4634,7 +4634,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "814",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4642,7 +4642,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "815",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4650,7 +4650,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "816",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4658,7 +4658,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "817",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4666,7 +4666,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "818",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4674,7 +4674,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "819",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4682,7 +4682,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "820",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4690,7 +4690,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "821",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4698,7 +4698,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "822",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4706,7 +4706,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "823",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4714,7 +4714,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "824",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4722,7 +4722,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "825",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4730,7 +4730,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "826",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4738,7 +4738,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "827",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4746,7 +4746,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "828",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4754,7 +4754,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "829",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4762,7 +4762,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "830",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4770,7 +4770,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "831",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4778,7 +4778,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "832",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4786,7 +4786,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "833",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4794,7 +4794,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "834",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4802,7 +4802,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "835",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4810,7 +4810,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "836",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4818,7 +4818,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "837",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4826,7 +4826,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "838",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4834,7 +4834,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "839",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4842,7 +4842,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "840",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4850,7 +4850,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "841",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4858,7 +4858,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "842",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4866,7 +4866,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "843",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4874,7 +4874,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "844",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4882,7 +4882,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "845",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4890,7 +4890,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "846",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4898,7 +4898,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "847",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4906,7 +4906,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "848",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4914,7 +4914,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "849",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4922,7 +4922,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "850",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4930,7 +4930,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "851",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4938,7 +4938,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "852",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4946,7 +4946,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "853",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4954,7 +4954,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "854",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4962,7 +4962,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "855",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4970,7 +4970,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "856",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4978,7 +4978,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "857",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4986,7 +4986,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "858",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -4994,7 +4994,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "859",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5002,7 +5002,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "860",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5010,7 +5010,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "861",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5018,7 +5018,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "862",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5026,7 +5026,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "863",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5034,7 +5034,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "864",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5042,7 +5042,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "865",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5050,7 +5050,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "866",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5058,7 +5058,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "867",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5066,7 +5066,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "868",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5074,7 +5074,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "869",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5082,7 +5082,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "870",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5090,7 +5090,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "871",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5098,7 +5098,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "872",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5106,7 +5106,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "873",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5114,7 +5114,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "874",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5122,7 +5122,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "875",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5130,7 +5130,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "876",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5138,7 +5138,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "877",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5146,7 +5146,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "878",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5154,7 +5154,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "879",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5162,7 +5162,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "880",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5170,7 +5170,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "881",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5178,7 +5178,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "882",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5186,7 +5186,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "883",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5194,7 +5194,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "884",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5202,7 +5202,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "885",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5210,7 +5210,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "886",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5218,7 +5218,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "887",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5226,7 +5226,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "888",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5234,7 +5234,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "889",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5242,7 +5242,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "890",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5250,7 +5250,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "891",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5258,7 +5258,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "892",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5266,7 +5266,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "893",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5274,7 +5274,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "894",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5282,7 +5282,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "895",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5290,7 +5290,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "896",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5298,7 +5298,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "897",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5306,7 +5306,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "898",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "
@@ -5314,7 +5314,7 @@
   {
     "country_code": "FI",
     "primary": true,
-    "bic": "DABAFIHH ",
+    "bic": "DABAFIHH",
     "bank_code": "899",
     "name": "DANSKE BANK A/S, FINLAND BRANCH ",
     "short_name": "DANSKE BANK A/S, FINLAND BRANCH "

--- a/schwifty/bank_registry/manual_ch.json
+++ b/schwifty/bank_registry/manual_ch.json
@@ -1,0 +1,226 @@
+[
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH80A",
+        "bank_code": "00268",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "ZKBKCHZZ80A",
+        "bank_code": "00700",
+        "name": "Z\u00fcrcher Kantonalbank",
+        "short_name": "Z\u00fcrcher Kantonalbank",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "CRESCHZZ",
+        "bank_code": "04835",
+        "name": "Credit Suisse (Switzerland) Ltd.",
+        "short_name": "Credit Suisse (Switzerland) Ltd.",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH80A",
+        "bank_code": "00240",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH",
+        "bank_code": "00233",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "CIMMCHGGXXX",
+        "bank_code": "08822",
+        "name": "CIM BANQUE SA",
+        "short_name": "CIM BANQUE SA",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "RAIFCH22XXX",
+        "bank_code": "80808",
+        "name": "Raiffeisen Schweiz Genossenschaft",
+        "short_name": "Raiffeisen Schweiz Genossenschaft",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "BLKBCH22",
+        "bank_code": "00769",
+        "name": "Basellandschaftliche Kantonalbank",
+        "short_name": "Basellandschaftliche Kantonalbank",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "RAIFCH22XXX",
+        "bank_code": "80102",
+        "name": "Raiffeisen Schweiz Genossenschaft",
+        "short_name": "Raiffeisen Schweiz Genossenschaft",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH80A",
+        "bank_code": "00228",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "CRESCHZZ80A",
+        "bank_code": "04835",
+        "name": "Credit Suisse (Switzerland) Ltd.",
+        "short_name": "Credit Suisse (Switzerland) Ltd.",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "POFICHBEXXX",
+        "bank_code": "09000",
+        "name": "PostFinance AG",
+        "short_name": "PostFinance AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "MIGRCHZZXXX",
+        "bank_code": "08401",
+        "name": "Migros Bank AG",
+        "short_name": "Migros Bank AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "BCNNCH22",
+        "bank_code": "00766",
+        "name": "Banque cantonale neuch\u00e2teloise",
+        "short_name": "Banque cantonale neuch\u00e2teloise",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH80A",
+        "bank_code": "00244",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH80A",
+        "bank_code": "00206",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH80A",
+        "bank_code": "00243",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "PIGUCH22",
+        "bank_code": "08777",
+        "name": "Piguet Galland & Cie SA",
+        "short_name": "Piguet Galland & Cie SA",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH80A",
+        "bank_code": "00260",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "BCVSCH2LXXX",
+        "bank_code": "00765",
+        "name": "Banque Cantonale du Valais",
+        "short_name": "Banque Cantonale du Valais",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "BLEMCHGG",
+        "bank_code": "08838",
+        "name": "Banque du L\u00e9man SA",
+        "short_name": "Banque du L\u00e9man SA",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "INCOCHZZXXX",
+        "bank_code": "08799",
+        "name": "InCore Bank AG",
+        "short_name": "InCore Bank AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "DUBACHGGXXX",
+        "bank_code": "08843",
+        "name": "Dukascopy Bank SA",
+        "short_name": "Dukascopy Bank SA",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH",
+        "bank_code": "00240",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "POSOCH22",
+        "bank_code": "08252",
+        "name": "Banca Popolare di Sondrio (Suisse) SA",
+        "short_name": "Banca Popolare di Sondrio (Suisse) SA",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "UBSWCHZH",
+        "bank_code": "00251",
+        "name": "UBS Switzerland AG",
+        "short_name": "UBS Switzerland AG",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "BCVLCH2L",
+        "bank_code": "00767",
+        "name": "Banque Cantonale Vaudoise",
+        "short_name": "Banque Cantonale Vaudoise",
+        "primary": true
+    },
+    {
+        "country_code": "CH",
+        "bic": "COBACHZHXXX",
+        "bank_code": "08836",
+        "name": "COMMERZBANK AG",
+        "short_name": "COMMERZBANK AG",
+        "primary": true
+    }
+]

--- a/schwifty/bank_registry/manual_fr.json
+++ b/schwifty/bank_registry/manual_fr.json
@@ -1,0 +1,2394 @@
+[
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP142",
+        "bank_code": "11425",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE DE NORMANDIE",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE DE NORMANDIE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPIFN",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPCOR",
+        "bank_code": "30066",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPP",
+        "bank_code": "10096",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP831",
+        "bank_code": "13106",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL TOULOUSE 31",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL TOULOUSE 31",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPAA",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "13807",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NOVUFR21XXX",
+        "bank_code": "11658",
+        "name": "NOUVELLE VAGUE",
+        "short_name": "NOUVELLE VAGUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "GRCSFRP1XXX",
+        "bank_code": "14628",
+        "name": "BANQUE DU GROUPE CASINO",
+        "short_name": "BANQUE DU GROUPE CASINO",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPBOR",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BFCORERXXXX",
+        "bank_code": "18719",
+        "name": "BANQUE FRANCAISE COMMERCIALE OCEAN INDIEN",
+        "short_name": "BANQUE FRANCAISE COMMERCIALE OCEAN INDIEN",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "17169",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NORDFRPP",
+        "bank_code": "30076",
+        "name": "CREDIT DU NORD",
+        "short_name": "CREDIT DU NORD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "16607",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP860",
+        "bank_code": "16006",
+        "name": "CREDIT AGRICOLE DU MORBIHAN",
+        "short_name": "CREDIT AGRICOLE DU MORBIHAN",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "16807",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BDEIFRPPXXX",
+        "bank_code": "11449",
+        "name": "BANQUE FIDUCIAL EN ABREGE FIDUBANQUE",
+        "short_name": "BANQUE FIDUCIAL EN ABREGE FIDUBANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPMED",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPBDX",
+        "bank_code": "10907",
+        "name": "BANQUE POPULAIRE AQUITAINE CENTRE ATLANTIQUE",
+        "short_name": "BANQUE POPULAIRE AQUITAINE CENTRE ATLANTIQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPCRN",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP820",
+        "bank_code": "12006",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DE LA CORSE",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DE LA CORSE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPSDR",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPXXX",
+        "bank_code": "10057",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BMRZFR21XXX",
+        "bank_code": "13379",
+        "name": "BANQUE MARZE SA",
+        "short_name": "BANQUE MARZE SA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BFBKFRP1XXX",
+        "bank_code": "16218",
+        "name": "BFORBANK",
+        "short_name": "BFORBANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "COURFR2T",
+        "bank_code": "10268",
+        "name": "BANQUE COURTOIS (SUCCESSEUR DE L'ANCIENNE MAISON COURTOIS & CIE DEPUIS 1760)",
+        "short_name": "BANQUE COURTOIS (SUCCESSEUR DE L'ANCIENNE MAISON COURTOIS & CIE DEPUIS 1760)",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "13507",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRP1XXX",
+        "bank_code": "14690",
+        "name": "CREDIT MUTUEL - CIC Banques",
+        "short_name": "CREDIT MUTUEL - CIC Banques",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SMCTFR2A",
+        "bank_code": "30077",
+        "name": "SOCIETE MARSEILLAISE DE CREDIT",
+        "short_name": "SOCIETE MARSEILLAISE DE CREDIT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPP",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BREDFRPP",
+        "bank_code": "10107",
+        "name": "BRED BANQUE POPULAIRE",
+        "short_name": "BRED BANQUE POPULAIRE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPDIJ",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP882",
+        "bank_code": "18206",
+        "name": "CAISS REGIO CREDI AGRIC MUTUEL PARIS IDF",
+        "short_name": "CAISS REGIO CREDI AGRIC MUTUEL PARIS IDF",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCOPFRPPXXX",
+        "bank_code": "42559",
+        "name": "CREDIT COOPERATIF",
+        "short_name": "CREDIT COOPERATIF",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "COURFR2TXXX",
+        "bank_code": "10268",
+        "name": "BANQUE COURTOIS (SUCCESSEUR DE L'ANCIENNE MAISON COURTOIS & CIE DEPUIS 1760)",
+        "short_name": "BANQUE COURTOIS (SUCCESSEUR DE L'ANCIENNE MAISON COURTOIS & CIE DEPUIS 1760)",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPREN",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "KOLBFR21",
+        "bank_code": "13259",
+        "name": "BANQUE KOLB",
+        "short_name": "BANQUE KOLB",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "10807",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNUGFR21XXX",
+        "bank_code": "13489",
+        "name": "BANQUE NUGER",
+        "short_name": "BANQUE NUGER",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AXABFRPPXXX",
+        "bank_code": "12548",
+        "name": "AXA BANQUE",
+        "short_name": "AXA BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPXXX",
+        "bank_code": "30027",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "OPSPFR21OLK",
+        "bank_code": "19733",
+        "name": "OLKY PAYMENT SERVICE PROVIDER",
+        "short_name": "OLKY PAYMENT SERVICE PROVIDER",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CFFRFRPPXXX",
+        "bank_code": "43199",
+        "name": "CREDIT FONCIER DE FRANCE",
+        "short_name": "CREDIT FONCIER DE FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CGCPFRP1XXX",
+        "bank_code": "18189",
+        "name": "COMPAGNIE GENERALE DE CREDITS AUX PARTICULIERS - CREDIPAR",
+        "short_name": "COMPAGNIE GENERALE DE CREDITS AUX PARTICULIERS - CREDIPAR",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMBRFR2BARK",
+        "bank_code": "15589",
+        "name": "CREDIT MUTUEL ARKEA",
+        "short_name": "CREDIT MUTUEL ARKEA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPXXX",
+        "bank_code": "41199",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIRERXXXX",
+        "bank_code": "19906",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DE LA REUNION",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DE LA REUNION",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CDCGFRPPXXX",
+        "bank_code": "40031",
+        "name": "CAISSE DES DEPOTS ET CONSIGNATIONS",
+        "short_name": "CAISSE DES DEPOTS ET CONSIGNATIONS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AFOPFR21XXX",
+        "bank_code": "16338",
+        "name": "AFONE PAIEMENT",
+        "short_name": "AFONE PAIEMENT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPGRE",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPAE",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPLIL",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "RALPFR2GXXX",
+        "bank_code": "10468",
+        "name": "BANQUE RHONE-ALPES",
+        "short_name": "BANQUE RHONE-ALPES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP817",
+        "bank_code": "11706",
+        "name": "CAISSE REG CREDIT AGRICOLE MUTUEL 17-79",
+        "short_name": "CAISSE REG CREDIT AGRICOLE MUTUEL 17-79",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "18715",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "13485",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCFRFRPP",
+        "bank_code": "30056",
+        "name": "HSBC FRANCE",
+        "short_name": "HSBC FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRP1ACF",
+        "bank_code": "41539",
+        "name": "CREDIT AGRICOLE LEASING & FACTORING",
+        "short_name": "CREDIT AGRICOLE LEASING & FACTORING",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP313",
+        "bank_code": "13135",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE DE MIDI PYRENEES",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE DE MIDI PYRENEES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "TRPUFRP1XXX",
+        "bank_code": "10071",
+        "name": "TRESOR PUBLIC",
+        "short_name": "TRESOR PUBLIC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP879",
+        "bank_code": "17906",
+        "name": "CAISSE REG CREDIT AGRI MUTUEL ANJOU MAIN",
+        "short_name": "CAISSE REG CREDIT AGRI MUTUEL ANJOU MAIN",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPCNE",
+        "bank_code": "10011",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PRIVFRPPXXX",
+        "bank_code": "24599",
+        "name": "MILLEIS BANQUE",
+        "short_name": "MILLEIS BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPTOU",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPMTZ",
+        "bank_code": "14707",
+        "name": "BANQUE POPULAIRE ALSACE LORRAINE CHAMPAGNE",
+        "short_name": "BANQUE POPULAIRE ALSACE LORRAINE CHAMPAGNE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP887",
+        "bank_code": "18706",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL BRIE PICARDIE",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL BRIE PICARDIE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BCMAFRPPXXX",
+        "bank_code": "23890",
+        "name": "ATTIJARIWAFA BANK EUROPE",
+        "short_name": "ATTIJARIWAFA BANK EUROPE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CITIFRPPXXX",
+        "bank_code": "11689",
+        "name": "CITIBANK INTERNATIONAL PLC",
+        "short_name": "CITIBANK INTERNATIONAL PLC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BATIFRP1XXX",
+        "bank_code": "30258",
+        "name": "BANQUE DU BATIMENT & DES TRAVAUX PUBLICS",
+        "short_name": "BANQUE DU BATIMENT & DES TRAVAUX PUBLICS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP844",
+        "bank_code": "14406",
+        "name": "CAISSE REG CREDIT AGRIC MUT VAL FRANCE",
+        "short_name": "CAISSE REG CREDIT AGRIC MUT VAL FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP867",
+        "bank_code": "16706",
+        "name": "CAISSE REG CREDIT AGRIC MUT NORD FRANCE",
+        "short_name": "CAISSE REG CREDIT AGRIC MUT NORD FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP822",
+        "bank_code": "12206",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DES COTES D'ARMOR",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DES COTES D'ARMOR",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CPMEFRPPXXX",
+        "bank_code": "18359",
+        "name": "BPIFRANCE FINANCEMENT",
+        "short_name": "BPIFRANCE FINANCEMENT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PRNSFRP1XXX",
+        "bank_code": "74202",
+        "name": "PREPAID FINANCIAL SERVICES LTD",
+        "short_name": "PREPAID FINANCIAL SERVICES LTD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "MRNGFR21XXX",
+        "bank_code": "16768",
+        "name": "MORNING",
+        "short_name": "MORNING",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NORDFRPP",
+        "bank_code": "30077",
+        "name": "CREDIT DU NORD",
+        "short_name": "CREDIT DU NORD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BDFEFRPP",
+        "bank_code": "30001",
+        "name": "BANQUE DE FRANCE",
+        "short_name": "BANQUE DE FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "TARNFR2L",
+        "bank_code": "10558",
+        "name": "BANQUE TARNEAUD",
+        "short_name": "BANQUE TARNEAUD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "14607",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "10907",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPBQ",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "11315",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMBRFR2BXXX",
+        "bank_code": "15589",
+        "name": "CREDIT MUTUEL ARKEA",
+        "short_name": "CREDIT MUTUEL ARKEA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP213",
+        "bank_code": "12135",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE DE BOURGOGNE FRANCHE-COMTE",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE DE BOURGOGNE FRANCHE-COMTE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPNFE",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPLIL",
+        "bank_code": "13507",
+        "name": "BANQUE POPULAIRE DU NORD",
+        "short_name": "BANQUE POPULAIRE DU NORD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPGN",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "TARNFR2LXXX",
+        "bank_code": "10558",
+        "name": "BANQUE TARNEAUD",
+        "short_name": "BANQUE TARNEAUD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPXXX",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFR2AXXX",
+        "bank_code": "15519",
+        "name": "CREDIT MUTUEL",
+        "short_name": "CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SOGEFRPPHPO",
+        "bank_code": "30003",
+        "name": "Inter Europe Conseil SAS",
+        "short_name": "Inter Europe Conseil SAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP836",
+        "bank_code": "13606",
+        "name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL",
+        "short_name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "14265",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BMMMFR2AXXX",
+        "bank_code": "13369",
+        "name": "MARTIN MAUREL",
+        "short_name": "MARTIN MAUREL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPBOR",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPPPG",
+        "bank_code": "16607",
+        "name": "BANQUE POPULAIRE DU SUD",
+        "short_name": "BANQUE POPULAIRE DU SUD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPAXXX",
+        "bank_code": "30066",
+        "name": "BANQUE FEDERATIVE DU CREDIT MUTUEL",
+        "short_name": "BANQUE FEDERATIVE DU CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BSUIFRPPXXX",
+        "bank_code": "31489",
+        "name": "CREDIT AGRICOLE CORPORATE AND INVESTMENT BANK",
+        "short_name": "CREDIT AGRICOLE CORPORATE AND INVESTMENT BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SOGEFRPPXXX",
+        "bank_code": "30003",
+        "name": "Inter Europe Conseil SAS",
+        "short_name": "Inter Europe Conseil SAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPP",
+        "bank_code": "10011",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIMQMXXXX",
+        "bank_code": "19806",
+        "name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL MARTINIQUE GUYANE",
+        "short_name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL MARTINIQUE GUYANE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "HRFRFRP1XXX",
+        "bank_code": "11438",
+        "name": "BANQUE HOTTINGUER",
+        "short_name": "BANQUE HOTTINGUER",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPARERXXXX",
+        "bank_code": "41919",
+        "name": "BNP PARIBAS REUNION",
+        "short_name": "BNP PARIBAS REUNION",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "17807",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP872",
+        "bank_code": "17206",
+        "name": "CREDIT AGRICOLE ALSACE VOSGES",
+        "short_name": "CREDIT AGRICOLE ALSACE VOSGES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "MOBQFR22XXX",
+        "bank_code": "16989",
+        "name": "MOBILIS BANQUE",
+        "short_name": "MOBILIS BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "STFEFR21XXX",
+        "bank_code": "21570",
+        "name": "STE FIRE DE LA NEF",
+        "short_name": "STE FIRE DE LA NEF",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPXXX",
+        "bank_code": "30047",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP866",
+        "bank_code": "16606",
+        "name": "CAISSE REG CREDIT AGRIC MUT NORMANDIE",
+        "short_name": "CAISSE REG CREDIT AGRIC MUT NORMANDIE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NORDFRPPXXX",
+        "bank_code": "30076",
+        "name": "CREDIT DU NORD",
+        "short_name": "CREDIT DU NORD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "FIDCFR21XXX",
+        "bank_code": "13179",
+        "name": "BANQUE FIDUCIAL",
+        "short_name": "BANQUE FIDUCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SBEXFRP1XXX",
+        "bank_code": "17679",
+        "name": "SOCIETE DE BANQUE ET D'EXPANSION",
+        "short_name": "SOCIETE DE BANQUE ET D'EXPANSION",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP810",
+        "bank_code": "11006",
+        "name": "CREDIT AGRICOLE MUTUEL CHAMPAGNE-BOURGOG",
+        "short_name": "CREDIT AGRICOLE MUTUEL CHAMPAGNE-BOURGOG",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BBVAFRPPXXX",
+        "bank_code": "41189",
+        "name": "BANCO BILBAO VIZCAYA ARGENTARIA",
+        "short_name": "BANCO BILBAO VIZCAYA ARGENTARIA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMBRFR2BCME",
+        "bank_code": "18829",
+        "name": "CREDIT MUTUEL ARKEA",
+        "short_name": "CREDIT MUTUEL ARKEA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CITIFRPP",
+        "bank_code": "11689",
+        "name": "CITIBANK INTERNATIONAL PLC",
+        "short_name": "CITIBANK INTERNATIONAL PLC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BCDMFRPPXXX",
+        "bank_code": "41439",
+        "name": "BANQUE CHAABI DU MAROC",
+        "short_name": "BANQUE CHAABI DU MAROC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "TRZOFR21XXX",
+        "bank_code": "16798",
+        "name": "TREEZOR",
+        "short_name": "TREEZOR",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP824",
+        "bank_code": "12406",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL CHARENTE-PERIGORD",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL CHARENTE-PERIGORD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPVER",
+        "bank_code": "18707",
+        "name": "BANQUE POPULAIRE VAL DE FRANCE",
+        "short_name": "BANQUE POPULAIRE VAL DE FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "DELUFR22XXX",
+        "bank_code": "12879",
+        "name": "BANQUE DELUBAC ET CIE",
+        "short_name": "BANQUE DELUBAC ET CIE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BDUPFR2SXXX",
+        "bank_code": "12939",
+        "name": "B",
+        "short_name": "A",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "FPELFR21XXX",
+        "bank_code": "16598",
+        "name": "FINANCIERE DES PAIEMENTS ELECTRONIQUES",
+        "short_name": "FINANCIERE DES PAIEMENTS ELECTRONIQUES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BCADNCNN",
+        "bank_code": "17499",
+        "name": "BANQUE CALEDONIENNE D'INVESTISSEMENT",
+        "short_name": "BANQUE CALEDONIENNE D'INVESTISSEMENT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BDFEFRPPCCT",
+        "bank_code": "30001",
+        "name": "BANQUE DE FRANCE",
+        "short_name": "BANQUE DE FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "17515",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NORDFRPPXXX",
+        "bank_code": "10268",
+        "name": "CREDIT DU NORD",
+        "short_name": "CREDIT DU NORD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BREDFRPPXXX",
+        "bank_code": "10107",
+        "name": "BRED BANQUE POPULAIRE",
+        "short_name": "BRED BANQUE POPULAIRE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BOFAFRPPXXX",
+        "bank_code": "41219",
+        "name": "BANK OF AMERICA, N.A. PARIS",
+        "short_name": "BANK OF AMERICA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFR2A",
+        "bank_code": "10278",
+        "name": "CREDIT MUTUEL",
+        "short_name": "CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "MONTFRPPXXX",
+        "bank_code": "30478",
+        "name": "MONTE PASCHI BANQUE SA",
+        "short_name": "MONTE PASCHI BANQUE SA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP871",
+        "bank_code": "17106",
+        "name": "CAISSE REG CREDIT AGRICOLE MUT SUD MEDIT",
+        "short_name": "CAISSE REG CREDIT AGRICOLE MUT SUD MEDIT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIRERX",
+        "bank_code": "19906",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DE LA REUNION",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DE LA REUNION",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPAXXX",
+        "bank_code": "11808",
+        "name": "BANQUE FEDERATIVE DU CREDIT MUTUEL",
+        "short_name": "BANQUE FEDERATIVE DU CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SOGENCNN",
+        "bank_code": "18319",
+        "name": "SOCIETE GENERALE CALEDONIENNE DE BANQUE",
+        "short_name": "SOCIETE GENERALE CALEDONIENNE DE BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BCHAFR21",
+        "bank_code": "10188",
+        "name": "BANQUE CHALUS",
+        "short_name": "BANQUE CHALUS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BSAVFR2CXXX",
+        "bank_code": "10548",
+        "name": "BANQUE DE SAVOIE",
+        "short_name": "BANQUE DE SAVOIE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP825",
+        "bank_code": "12506",
+        "name": "CREDIT AGRICOLE MUTUEL DE FRANCHE COMTE",
+        "short_name": "CREDIT AGRICOLE MUTUEL DE FRANCHE COMTE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "TRAVFRPPXXX",
+        "bank_code": "42649",
+        "name": "BANQUE TRAVELEX SA",
+        "short_name": "BANQUE TRAVELEX SA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP894",
+        "bank_code": "19406",
+        "name": "CAISSE REG CRED AGRIC MUT TOURAIN POITOU",
+        "short_name": "CAISSE REG CRED AGRIC MUT TOURAIN POITOU",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP895",
+        "bank_code": "19506",
+        "name": "CAISSE REGION CRED AGR MUTUEL CENT OUEST",
+        "short_name": "CAISSE REGION CRED AGR MUTUEL CENT OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMBRFR2B",
+        "bank_code": "15589",
+        "name": "CREDIT MUTUEL ARKEA",
+        "short_name": "CREDIT MUTUEL ARKEA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP382",
+        "bank_code": "13825",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE DE RHONE ALPES",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE DE RHONE ALPES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFR2AXXX",
+        "bank_code": "10278",
+        "name": "CREDIT MUTUEL",
+        "short_name": "CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CGDIFRPP",
+        "bank_code": "12619",
+        "name": "CAIXA GERAL DE DEPOSITOS SA",
+        "short_name": "CAIXA GERAL DE DEPOSITOS SA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "10207",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP871",
+        "bank_code": "18715",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE D'AUVERGNE ET DU LIMOUSIN",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE D'AUVERGNE ET DU LIMOUSIN",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP813",
+        "bank_code": "11306",
+        "name": "CREDIT AGRICOLE ALPES PROVENCE",
+        "short_name": "CREDIT AGRICOLE ALPES PROVENCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "FPELFR21",
+        "bank_code": "16598",
+        "name": "FINANCIERE DES PAIEMENTS ELECTRONIQUES",
+        "short_name": "FINANCIERE DES PAIEMENTS ELECTRONIQUES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPP",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NATXFRPPBPS",
+        "bank_code": "18919",
+        "name": "NATIXIS",
+        "short_name": "NATIXIS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPNTE",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "RALPFR2G",
+        "bank_code": "10468",
+        "name": "BANQUE RHONE-ALPES",
+        "short_name": "BANQUE RHONE-ALPES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIGPGX",
+        "bank_code": "14006",
+        "name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL",
+        "short_name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP831",
+        "bank_code": "18315",
+        "name": "CAISSE EPARGNE PREVOYANCE COTE D'AZUR",
+        "short_name": "CAISSE EPARGNE PREVOYANCE COTE D'AZUR",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP883",
+        "bank_code": "18306",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DE NORMANDIE-SEINE",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DE NORMANDIE-SEINE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BPSMFRPPXXX",
+        "bank_code": "12579",
+        "name": "BANQUE BCP",
+        "short_name": "BANQUE BCP",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP847",
+        "bank_code": "14706",
+        "name": "CAISSE REG CRED AGRIC MUT ATLANTIQUE VEN",
+        "short_name": "CAISSE REG CRED AGRIC MUT ATLANTIQUE VEN",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP802",
+        "bank_code": "10206",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DU NORD EST",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DU NORD EST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "KOLBFR21XXX",
+        "bank_code": "13259",
+        "name": "BANQUE KOLB",
+        "short_name": "BANQUE KOLB",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPCRM",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPSCE",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPTLS",
+        "bank_code": "17807",
+        "name": "BANQUE POPULAIRE OCCITANE",
+        "short_name": "BANQUE POPULAIRE OCCITANE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SORMFR2NXXX",
+        "bank_code": "12280",
+        "name": "SOCRAM BANQUE",
+        "short_name": "SOCRAM BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CHASFRPPXXX",
+        "bank_code": "30628",
+        "name": "JPMORGAN CHASE BANK, N.A.",
+        "short_name": "JPMORGAN CHASE BANK, N.A.",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP444",
+        "bank_code": "14445",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE BRETAGNE - PAYS DE LOIRE",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE BRETAGNE - PAYS DE LOIRE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "QNTOFRP1XXX",
+        "bank_code": "16958",
+        "name": "OLINDA",
+        "short_name": "OLINDA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BCMAFRPP",
+        "bank_code": "23890",
+        "name": "ATTIJARIWAFA BANK EUROPE",
+        "short_name": "ATTIJARIWAFA BANK EUROPE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "ESCBFRPPXXX",
+        "bank_code": "44149",
+        "name": "BANQUE D'ESCOMPTE",
+        "short_name": "BANQUE D'ESCOMPTE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "GPBAFRPP",
+        "bank_code": "18370",
+        "name": "ORANGE BANK",
+        "short_name": "ORANGE BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPMON",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "KREDFRPPXXX",
+        "bank_code": "27800",
+        "name": "KBC BANK NV PARIS",
+        "short_name": "KBC BANK NV PARIS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPXXX",
+        "bank_code": "10096",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP861",
+        "bank_code": "16106",
+        "name": "CAISSE REG CREDIT AGRICOL MUTUEL LORRAIN",
+        "short_name": "CAISSE REG CREDIT AGRICOL MUTUEL LORRAIN",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CFFIFR21XXX",
+        "bank_code": "14940",
+        "name": "COFIDIS",
+        "short_name": "COFIDIS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "12135",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPXXX",
+        "bank_code": "30087",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "LAZPFRPPXXX",
+        "bank_code": "30748",
+        "name": "LAZARD FRERES BANQUE",
+        "short_name": "LAZARD FRERES BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP881",
+        "bank_code": "18106",
+        "name": "CRCAM DES SAVOIE",
+        "short_name": "CRCAM DES SAVOIE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "14707",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CGDIFRPPXXX",
+        "bank_code": "12619",
+        "name": "CAIXA GERAL DE DEPOSITOS SA",
+        "short_name": "CAIXA GERAL DE DEPOSITOS SA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPDJN",
+        "bank_code": "10807",
+        "name": "BANQUE POPULAIRE BOURGOGNE FRANCHE-COMTE",
+        "short_name": "BANQUE POPULAIRE BOURGOGNE FRANCHE-COMTE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP839",
+        "bank_code": "13906",
+        "name": "CAISSE REGION CREDIT AGRIC MUTUEL SUDRA",
+        "short_name": "CAISSE REGION CREDIT AGRIC MUTUEL SUDRA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "INGBFRPP",
+        "bank_code": "30438",
+        "name": "ING BANK FRANCE COMMERCIAL BANKING",
+        "short_name": "ING BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP333",
+        "bank_code": "13335",
+        "name": "CAISSE D EPARGNE ET DE PREVOYANCE AQUITAINE POITOU CHARENTES",
+        "short_name": "CAISSE D EPARGNE ET DE PREVOYANCE AQUITAINE POITOU CHARENTES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCFRFRPPXXX",
+        "bank_code": "30056",
+        "name": "HSBC FRANCE",
+        "short_name": "HSBC FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPVD",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRP1MON",
+        "bank_code": "14690",
+        "name": "CREDIT MUTUEL - CIC Banques",
+        "short_name": "CREDIT MUTUEL - CIC Banques",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPFDF",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BARCFRPC",
+        "bank_code": "30588",
+        "name": "B",
+        "short_name": "A",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "LAYDFR2W",
+        "bank_code": "10228",
+        "name": "BANQUE LAYDERNIER",
+        "short_name": "BANQUE LAYDERNIER",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "14505",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "RCINFRPPXXX",
+        "bank_code": "11188",
+        "name": "RCI BANQUE",
+        "short_name": "RCI BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "COBAFRPXXXX",
+        "bank_code": "17629",
+        "name": "COMMERZBANK",
+        "short_name": "COMMERZBANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPNAN",
+        "bank_code": "13807",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP878",
+        "bank_code": "17806",
+        "name": "CAISSE REG CREDIT AGRICOLE MUT CTRE-EST",
+        "short_name": "CAISSE REG CREDIT AGRICOLE MUT CTRE-EST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "18707",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NATXFRPPPAI",
+        "bank_code": "15930",
+        "name": "NATIXIS",
+        "short_name": "NATIXIS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPROU",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "13825",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "15135",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPAXXX",
+        "bank_code": "10278",
+        "name": "BANQUE FEDERATIVE DU CREDIT MUTUEL",
+        "short_name": "BANQUE FEDERATIVE DU CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "18315",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "LBDIFRP1XXX",
+        "bank_code": "16908",
+        "name": "MA FRENCH BANK",
+        "short_name": "MA FRENCH BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "13135",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFR2AXXX",
+        "bank_code": "15489",
+        "name": "CREDIT MUTUEL",
+        "short_name": "CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP868",
+        "bank_code": "16806",
+        "name": "CAISSE REG CREDIT AGRIC MUT CTRE FRANCE",
+        "short_name": "CAISSE REG CREDIT AGRIC MUT CTRE FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP812",
+        "bank_code": "11206",
+        "name": "CRCAM NORD MIDI-PYRENEES",
+        "short_name": "CRCAM NORD MIDI-PYRENEES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "DEUTFRPPXXX",
+        "bank_code": "17789",
+        "name": "DEUTSCHE BANK AG",
+        "short_name": "DEUTSCHE BANK AG",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPCLE",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPPAR",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPNCY",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "ESCBFRPP",
+        "bank_code": "44149",
+        "name": "BANQUE D'ESCOMPTE",
+        "short_name": "BANQUE D'ESCOMPTE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPMAR",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPCHA",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "ISAEFRPPXXX",
+        "bank_code": "18129",
+        "name": "CACEIS BANK",
+        "short_name": "CACEIS BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "11425",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPLYO",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPSTR",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFR2AXXX",
+        "bank_code": "11899",
+        "name": "CREDIT MUTUEL",
+        "short_name": "CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFR2AXXX",
+        "bank_code": "11628",
+        "name": "CREDIT MUTUEL",
+        "short_name": "CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP833",
+        "bank_code": "13306",
+        "name": "CAISSE REG CREDIT AGRI MUTUEL AQUITAINE",
+        "short_name": "CAISSE REG CREDIT AGRI MUTUEL AQUITAINE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SOAPFR22XXX",
+        "bank_code": "19870",
+        "name": "CARREFOUR BANQUE",
+        "short_name": "CARREFOUR BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP829",
+        "bank_code": "12906",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DU FINISTERE",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DU FINISTERE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "EDPIFR21XXX",
+        "bank_code": "16658",
+        "name": "EDENRED PAIEMENT",
+        "short_name": "EDENRED PAIEMENT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP848",
+        "bank_code": "14806",
+        "name": "CAISSE REG CREDIT AGRI MUTUEL CTRE LOIRE",
+        "short_name": "CAISSE REG CREDIT AGRI MUTUEL CTRE LOIRE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP891",
+        "bank_code": "19106",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL PROVENCE COTE D'AZUR (ALPES DE HAUTE PROVENCE - ALPES MARITIMES - VAR)",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL PROVENCE COTE D'AZUR (ALPES DE HAUTE PROVENCE - ALPES MARITIMES - VAR)",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "EDELFRP1XXX",
+        "bank_code": "13149",
+        "name": "BANQUE EDEL SNC",
+        "short_name": "BANQUE EDEL SNC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPPXXX",
+        "bank_code": "30006",
+        "name": "CREDIT AGRICOLE SA",
+        "short_name": "CREDIT AGRICOLE SA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPXXX",
+        "bank_code": "30568",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SFBSFRP1XXX",
+        "bank_code": "14749",
+        "name": "PSA BANQUE FRANCE",
+        "short_name": "PSA BANQUE FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "14445",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPTX",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIGPGXXXX",
+        "bank_code": "14006",
+        "name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL",
+        "short_name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP845",
+        "bank_code": "14506",
+        "name": "CR CREDIT AGRICOLE MUTUEL LOIRE HTE LOIR",
+        "short_name": "CR CREDIT AGRICOLE MUTUEL LOIRE HTE LOIR",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPAC",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPA",
+        "bank_code": "11808",
+        "name": "BANQUE FEDERATIVE DU CREDIT MUTUEL",
+        "short_name": "BANQUE FEDERATIVE DU CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPLZ",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPP039",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "16275",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPPXXX",
+        "bank_code": "13335",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPENG",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPPXXX",
+        "bank_code": "30066",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "short_name": "CREDIT INDUSTRIEL ET COMMERCIAL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPMAR",
+        "bank_code": "14607",
+        "name": "BANQUE POPULAIRE MEDITERRANEE",
+        "short_name": "BANQUE POPULAIRE MEDITERRANEE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPCAY",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP",
+        "bank_code": "14806",
+        "name": "CREDIT AGRICOLE SA",
+        "short_name": "CREDIT AGRICOLE SA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BSPFFRPPXXX",
+        "bank_code": "40978",
+        "name": "BANQUE PALATINE",
+        "short_name": "BANQUE PALATINE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPNEU",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPBTE",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIMQMX",
+        "bank_code": "19806",
+        "name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL MARTINIQUE GUYANE",
+        "short_name": "CAISSE REGIONALE CREDIT AGRICOLE MUTUEL MARTINIQUE GUYANE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPORE",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP513",
+        "bank_code": "15135",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE GRAND EST EUROPE",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE GRAND EST EUROPE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPEE",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCMOFR21XXX",
+        "bank_code": "16560",
+        "name": "CAISSE DE CREDIT MUNICIPAL DE BORDEAUX",
+        "short_name": "CAISSE DE CREDIT MUNICIPAL DE BORDEAUX",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP751",
+        "bank_code": "17515",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE ILE-DE-FRANCE",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE ILE-DE-FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NORDFRPP",
+        "bank_code": "13489",
+        "name": "CREDIT DU NORD",
+        "short_name": "CREDIT DU NORD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PSSTFRPPLIM",
+        "bank_code": "20041",
+        "name": "LA BANQUE POSTALE",
+        "short_name": "LA BANQUE POSTALE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPGRE",
+        "bank_code": "16807",
+        "name": "BANQUE POPULAIRE AUVERGNE RHONE ALPES",
+        "short_name": "BANQUE POPULAIRE AUVERGNE RHONE ALPES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NSMBFRPPXXX",
+        "bank_code": "30788",
+        "name": "BANQUE NEUFLIZE OBC",
+        "short_name": "BANQUE NEUFLIZE OBC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP426",
+        "bank_code": "14265",
+        "name": "CAISSE EPARGNE PREVO LOIRE DROME ARDECHE",
+        "short_name": "CAISSE EPARGNE PREVO LOIRE DROME ARDECHE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFR2AXXX",
+        "bank_code": "16159",
+        "name": "CREDIT MUTUEL",
+        "short_name": "CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PREUFRP1XXX",
+        "bank_code": "44319",
+        "name": "BPE",
+        "short_name": "BPE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP131",
+        "bank_code": "11315",
+        "name": "CAISSE D'EPARGNE CEPAC",
+        "short_name": "CAISSE D'EPARGNE CEPAC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "LAYDFR2WXXX",
+        "bank_code": "10228",
+        "name": "BANQUE LAYDERNIER",
+        "short_name": "BANQUE LAYDERNIER",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP627",
+        "bank_code": "16275",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE HAUTS DE FRANCE",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE HAUTS DE FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BOUSFRPPXXX",
+        "bank_code": "40618",
+        "name": "BOURSORAMA",
+        "short_name": "BOURSORAMA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP835",
+        "bank_code": "13506",
+        "name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DU LANGUEDOC",
+        "short_name": "CAISSE REGIONALE DE CREDIT AGRICOLE MUTUEL DU LANGUEDOC",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRP1XXX",
+        "bank_code": "10096",
+        "name": "CREDIT MUTUEL - CIC Banques",
+        "short_name": "CREDIT MUTUEL - CIC Banques",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPMTG",
+        "bank_code": "10207",
+        "name": "BANQUE POPULAIRE RIVES DE PARIS",
+        "short_name": "BANQUE POPULAIRE RIVES DE PARIS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRPP869",
+        "bank_code": "16906",
+        "name": "CREDIT AGRICOLE MUTUEL PYRENEES GASCOGNE",
+        "short_name": "CREDIT AGRICOLE MUTUEL PYRENEES GASCOGNE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPPXV",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAFRPPIFO",
+        "bank_code": "30004",
+        "name": "BNP PARIBAS",
+        "short_name": "BNP PARIBAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPCFR21XXX",
+        "bank_code": "18020",
+        "name": "BNP PARIBAS FACTOR",
+        "short_name": "BNP PARIBAS FACTOR",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "ISAEFRPP",
+        "bank_code": "18129",
+        "name": "CACEIS BANK",
+        "short_name": "CACEIS BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CCBPFRPPXXX",
+        "bank_code": "15607",
+        "name": "BANQUE POPULAIRE GRAND OUEST",
+        "short_name": "BANQUE POPULAIRE GRAND OUEST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BFCOYTYTXXX",
+        "bank_code": "18719",
+        "name": "BANQUE FRANCAISE COMMERCIALE DE LOCEAN INDIEN",
+        "short_name": "BANQUE FRANCAISE COMMERCIALE DE LOCEAN INDIEN",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "UTUBFRPPXXX",
+        "bank_code": "43849",
+        "name": "TUNISIAN FOREIGN BANK",
+        "short_name": "TUNISIAN FOREIGN BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BREUFR22XXX",
+        "bank_code": "14818",
+        "name": "BANCA REGIONALE EUROPEA S.P.A.",
+        "short_name": "BANCA REGIONALE EUROPEA S.P.A.",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BCADNCNNXXX",
+        "bank_code": "17499",
+        "name": "BANQUE CALEDONIENNE D'INVESTISSEMENT",
+        "short_name": "BANQUE CALEDONIENNE D'INVESTISSEMENT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP348",
+        "bank_code": "13485",
+        "name": "CAISSE EPARGNE PREVOYANCE LANGUEDOC ROUSSILLON",
+        "short_name": "CAISSE EPARGNE PREVOYANCE LANGUEDOC ROUSSILLON",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "PRNSFRP1XXX",
+        "bank_code": "21833",
+        "name": "PREPAID FINANCIAL SERVICES LTD",
+        "short_name": "PREPAID FINANCIAL SERVICES LTD",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMBRFR2B",
+        "bank_code": "18829",
+        "name": "CREDIT MUTUEL ARKEA",
+        "short_name": "CREDIT MUTUEL ARKEA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNUGFR21",
+        "bank_code": "13489",
+        "name": "BANQUE NUGER",
+        "short_name": "BANQUE NUGER",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BIKCFRP1XXX",
+        "bank_code": "15818",
+        "name": "BINCKBANK",
+        "short_name": "BINCKBANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGFBFRCCXXX",
+        "bank_code": "12240",
+        "name": "ALLIANZ BANQUE",
+        "short_name": "ALLIANZ BANQUE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BCITFRPP",
+        "bank_code": "10128",
+        "name": "INTESA SANPAOLO SPA",
+        "short_name": "INTESA SANPAOLO SPA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "FTNOFRP1XXX",
+        "bank_code": "14518",
+        "name": "ARKEA DIRECT BANK",
+        "short_name": "ARKEA DIRECT BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SOGEFRPP",
+        "bank_code": "30003",
+        "name": "Inter Europe Conseil SAS",
+        "short_name": "Inter Europe Conseil SAS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CEPAFRPP450",
+        "bank_code": "14505",
+        "name": "CAISSE D'EPARGNE ET DE PREVOYANCE LOIRE-CENTRE",
+        "short_name": "CAISSE D'EPARGNE ET DE PREVOYANCE LOIRE-CENTRE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFR2AXXX",
+        "bank_code": "15629",
+        "name": "CREDIT MUTUEL",
+        "short_name": "CREDIT MUTUEL",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CRLYFRPPXXX",
+        "bank_code": "30002",
+        "name": "CREDIT LYONNAIS",
+        "short_name": "CREDIT LYONNAIS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BOFAFRPP",
+        "bank_code": "41219",
+        "name": "BANK OF AMERICA, N.A. PARIS",
+        "short_name": "BANK OF AMERICA",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "INGBFR21XXX",
+        "bank_code": "30438",
+        "name": "ING BANK FRANCE-RETAIL BANKING (ING DIRECT)",
+        "short_name": "ING DIRECT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NATXFRPPXXX",
+        "bank_code": "30007",
+        "name": "NATIXIS",
+        "short_name": "NATIXIS",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SMCTFR2AXXX",
+        "bank_code": "30077",
+        "name": "SOCIETE MARSEILLAISE DE CREDIT",
+        "short_name": "SOCIETE MARSEILLAISE DE CREDIT",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BSUIFRPP",
+        "bank_code": "31489",
+        "name": "CREDIT AGRICOLE CORPORATE AND INVESTMENT BANK",
+        "short_name": "CREDIT AGRICOLE CORPORATE AND INVESTMENT BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "FXBBFRPP",
+        "bank_code": "20033",
+        "name": "IBANFIRST",
+        "short_name": "IBANFIRST",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "GPBAFRPPXXX",
+        "bank_code": "18370",
+        "name": "ORANGE BANK",
+        "short_name": "ORANGE BANK",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BNPAMQMXXXX",
+        "bank_code": "13088",
+        "name": "BANQUE NATIONALE DE PARIS SUCCURSALE DE FORT DE FRANCE",
+        "short_name": "BANQUE NATIONALE DE PARIS SUCCURSALE DE FORT DE FRANCE",
+        "primary": true
+    }
+]

--- a/schwifty/bank_registry/manual_gb.json
+++ b/schwifty/bank_registry/manual_gb.json
@@ -1,10 +1,298 @@
 [
-  {
+    {
     "primary": true,
     "name": "HALIFAX (A TRADING NAME OF BANK OF SCOTLAND PLC)",
     "short_name": "HALIFAX",
     "bank_code": "HLFX",
     "bic": "HLFXGB21N85",
     "country_code": "GB"
-  }
+    },
+    {
+        "country_code": "GB",
+        "bic": "ABBYGB2LXXX",
+        "bank_code": "ABBY",
+        "name": "SANTANDER UK PLC",
+        "short_name": "SANTANDER UK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "BARCGB22XXX",
+        "bank_code": "BARC",
+        "name": "BARCLAYS BANK PLC",
+        "short_name": "BARCLAYS BANK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "BOFAGB22VAM",
+        "bank_code": "BOFA",
+        "name": "BANK OF AMERICA, N.A. LONDON",
+        "short_name": "BANK OF AMERICA",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "COUTGB22XXX",
+        "bank_code": "COUT",
+        "name": "COUTTS & COMPANY",
+        "short_name": "COUTTS & COMPANY",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "MIDLGB22XXX",
+        "bank_code": "MIDL",
+        "name": "HSBC BANK PLC",
+        "short_name": "HSBC BANK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "PNBPGB2L",
+        "bank_code": "PNBP",
+        "name": "WELLS FARGO BANK, N.A., LONDON BRANCH",
+        "short_name": "WELLS FARGO BANK",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "PRTCGB21",
+        "bank_code": "PRTC",
+        "name": "PREPAY TECHNOLOGIES LIMITED",
+        "short_name": "PREPAY TECHNOLOGIES LIMITED",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "LOYDGB2L",
+        "bank_code": "BOFS",
+        "name": "LLOYDS BANK PLC",
+        "short_name": "LLOYDS BANK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "DEUTGB2LXXX",
+        "bank_code": "DEUT",
+        "name": "DEUTSCHE BANK AG",
+        "short_name": "DEUTSCHE BANK AG",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "COBAGB2XXXX",
+        "bank_code": "COBA",
+        "name": "COMMERZBANK AG",
+        "short_name": "COMMERZBANK AG",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "TCCLGB31XXX",
+        "bank_code": "TCCL",
+        "name": "THE CURRENCY CLOUD LIMITED",
+        "short_name": "THE CURRENCY CLOUD LIMITED",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "PAYRGB21",
+        "bank_code": "PAYR",
+        "name": "PAYRNET LIMITED",
+        "short_name": "PAYRNET LIMITED",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "SVBKGB2L",
+        "bank_code": "SVBK",
+        "name": "SILICON VALLEY BANK",
+        "short_name": "SILICON VALLEY BANK",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "RBOSGB2LXXX",
+        "bank_code": "RBOS",
+        "name": "THE ROYAL BANK OF SCOTLAND PUBLIC LIMITED COMPANY",
+        "short_name": "THE ROYAL BANK OF SCOTLAND PUBLIC LIMITED COMPANY",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "PAEDGB21XXX",
+        "bank_code": "PAED",
+        "name": "PAYSEND PLC",
+        "short_name": "PAYSEND PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "HBUKGB4B",
+        "bank_code": "HBUK",
+        "name": "HSBC UK BANK PLC",
+        "short_name": "HSBC UK BANK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "LOYDGB2L",
+        "bank_code": "LOYD",
+        "name": "LLOYDS BANK PLC",
+        "short_name": "LLOYDS BANK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "REVOGB21XXX",
+        "bank_code": "REVO",
+        "name": "REVOLUT LTD",
+        "short_name": "REVOLUT LTD",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "CLJUGB21XXX",
+        "bank_code": "CLJU",
+        "name": "Clear Junction Limited",
+        "short_name": "Clear Junction Limited",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "PRTCGB21XXX",
+        "bank_code": "PRTC",
+        "name": "PREPAY TECHNOLOGIES LIMITED",
+        "short_name": "PREPAY TECHNOLOGIES LIMITED",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "FTSBGB2L",
+        "bank_code": "FTSB",
+        "name": "ABN AMRO BANK N.V. UK BRANCH (FORMELY KNOWN AS FORTIS BANK (NEDERLAND) N.V. LONDON)",
+        "short_name": "ABN AMRO BANK ",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "BOFAGB22",
+        "bank_code": "BOFA",
+        "name": "BANK OF AMERICA, N.A. LONDON",
+        "short_name": "BANK OF AMERICA",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "CITIGB2L",
+        "bank_code": "CITI",
+        "name": "CITIBANK N.A.",
+        "short_name": "CITIBANK N.A.",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "BUKBGB22",
+        "bank_code": "BUKB",
+        "name": "BARCLAYS BANK UK PLC",
+        "short_name": "BARCLAYS BANK UK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "NWBKGB2LXXX",
+        "bank_code": "NWBK",
+        "name": "NATIONAL WESTMINSTER BANK PUBLIC LIMITED COMPANY",
+        "short_name": "NATIONAL WESTMINSTER BANK PUBLIC LIMITED COMPANY",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "REVOGB21",
+        "bank_code": "REVO",
+        "name": "REVOLUT LTD",
+        "short_name": "REVOLUT LTD",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "DEUTDEFFXXX",
+        "bank_code": "DEUT",
+        "name": "DEUTSCHE BANK AKTIENGESELLSCHAFT",
+        "short_name": "DEUTSCHE BANK AKTIENGESELLSCHAFT",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "MYMBGB2LXXX",
+        "bank_code": "MYMB",
+        "name": "METRO BANK PLC",
+        "short_name": "METRO BANK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "BOFAGB22XXX",
+        "bank_code": "BOFA",
+        "name": "BANK OF AMERICA, N.A. LONDON",
+        "short_name": "BANK OF AMERICA",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "BUKBGB22XXX",
+        "bank_code": "BUKB",
+        "name": "BARCLAYS BANK UK PLC",
+        "short_name": "BARCLAYS BANK UK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "BARCGB22",
+        "bank_code": "BARC",
+        "name": "BARCLAYS BANK PLC",
+        "short_name": "BARCLAYS BANK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "RAPHGB41XXX",
+        "bank_code": "RAPH",
+        "name": "R RAPHAELS AND SONS PLC",
+        "short_name": "R RAPHAELS AND SONS PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "HBUKGB4BXXX",
+        "bank_code": "HBUK",
+        "name": "HSBC UK BANK PLC",
+        "short_name": "HSBC UK BANK PLC",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "EPMTGB2LXXX",
+        "bank_code": "EPMT",
+        "name": "EPAYMENTS SYSTEMS LIMITED",
+        "short_name": "EPAYMENTS SYSTEMS LIMITED",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "CHASGB2LXXX",
+        "bank_code": "CHAS",
+        "name": "JPMORGAN CHASE BANK, N.A",
+        "short_name": "JPMORGAN CHASE BANK, N.A",
+        "primary": true
+    },
+    {
+        "country_code": "GB",
+        "bic": "MYMBGB2L",
+        "bank_code": "MYMB",
+        "name": "METRO BANK PLC",
+        "short_name": "METRO BANK PLC",
+        "primary": true
+    }
 ]

--- a/scripts/get_bank_registry_fi.py
+++ b/scripts/get_bank_registry_fi.py
@@ -19,7 +19,7 @@ def process():
         {
             "country_code": "FI",
             "primary": True,
-            "bic": bic.value.upper(),
+            "bic": bic.value.upper().strip(),
             "bank_code": bank_code.value,
             "name": name.value,
             "short_name": name.value,


### PR DESCRIPTION
Hello ! Here is some data we can use in this lib. Thanks for having created it (& maintained)

The data is generated from a (private) list of IBANs / BICs. The bank name is extracted from LEI dataset (details below). Then the bank code is extracted using `schwifty`.
For most of the data, it should be fine (I checked the more common).


### Lei Dataset
Maybe you know already what is it, but since I found no mention of it, I'm writing a quick summary just in case.

Basically, all financials actors have a unique identifier called *LEI* (Legal Entity Identifier), and for this LEI, some metadata are attached (notably, bank name). Finally there is a mapping between BICs and LEIs, so you can retrieve bank name from BIC.

*References*
- [glei website](https://www.gleif.org/en/about-lei/introducing-the-legal-entity-identifier-lei): organization website who maintain this index
- [lei_file](https://www.gleif.org/en/lei-data/gleif-concatenated-file/download-the-concatenated-file#): big xml file to parse (can give you the scripts I've used to parse it, but didn't know where to put it)
- [bic_to_lei_mapping_file](https://www.gleif.org/en/lei-data/lei-mapping/download-bic-to-lei-relationship-files#): clean csv with bic & lei

Feel free if you have questions/comments !