### PR TITLE
Compare check digits if quick check passes

### DIFF
--- a/schwifty/iban.py
+++ b/schwifty/iban.py
@@ -199,7 +199,7 @@ class IBAN(Base):
             raise ValueError("Invalid characters in IBAN {}".format(self.compact))
 
     def _validate_checksum(self):
-        if self.numeric % 97 != 1:
+        if self.numeric % 97 != 1 or self._calc_checksum_digits() != self.checksum_digits:
             raise ValueError("Invalid checksum digits")
 
     def _validate_length(self):

--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -90,10 +90,16 @@ valid = [
 invalid = [
     "DE89 3704 0044 0532 0130",  # Too short
     "DE89 3704 0044 0532 0130 0000",  # Too long
+    "GB96 BARC 2020 1530 0934 591",  # Too long
     "XX89 3704 0044 0532 0130 00",  # Wrong country-code
     "DE99 3704 0044 0532 0130 00",  # Wrong check digits
     "DEAA 3704 0044 0532 0130 00",  # Wrong format (check digits)
+    "GB2L ABBY 0901 2857 2017 07",  # Wrong format (check digits)
     "DE89 AA04 0044 0532 0130 00",  # Wrong format (country specific)
+    "GB12 BARC 2020 1530 093A 59",  # Wrong account format (country specific)
+    "GB01 BARC 2071 4583 6083 87",  # Wrong checksum digits
+    "GB00 HLFX 1101 6111 4553 65",  # Wrong checksum digits
+    "GB94 BARC 2020 1530 0934 59",  # Wrong checksum digits
 ]
 
 


### PR DESCRIPTION
Check digits might still be invalid even if the condition

numeric(IBAN) % mod 97 == 1

applies. So the above is a necessary but not a sufficient condition.

closes #42 