### PR TITLE
Add Sweden as available for BIC class usage

### DIFF
--- a/schwifty/bic.py
+++ b/schwifty/bic.py
@@ -98,6 +98,7 @@ class BIC(common.Base):
             * Poland
             * Slovenia
             * Spain
+            * Sweden
             * Switzerland
         """
         try:


### PR DESCRIPTION
I just found that I did not add Sweden to this list in `class BIC`