### PR TITLE
Specify encoding when reading registry files

### DIFF
--- a/schwifty/registry.py
+++ b/schwifty/registry.py
@@ -44,7 +44,7 @@ def get(name: str) -> Union[Dict, List[Dict]]:
         directory = files(__package__) / f"{name}_registry"
         assert isinstance(directory, pathlib.Path)
         for entry in sorted(directory.glob("*.json")):
-            with entry.open() as fp:
+            with entry.open(encoding='utf-8') as fp:
                 chunk = json.load(fp)
                 if data is None:
                     data = chunk


### PR DESCRIPTION
This fixes an issue that occurs on platforms that don't use UTF-8 as default encoding