### PR TITLE
Update banco popular

### DIFF
--- a/schwifty/bank_registry/manual_es.json
+++ b/schwifty/bank_registry/manual_es.json
@@ -6,5 +6,21 @@
     "name": "N26 BANK GMBH, SUCURSAL EN ESPAÑA",
     "short_name": "N26 BANK GMBH, SUCURSAL EN ESPAÑA",
     "primary": true
+  },
+  {
+    "country_code": "ES",
+    "primary": true,
+    "bank_code": "0075",
+    "bic": "BSCHESMM",
+    "name": "BANCO POPULAR ESPA\u00d1OL, S.A.",
+    "short_name": "POPULAR ESPA\u00d1OL"
+  },
+  {
+    "country_code": "ES",
+    "primary": true,
+    "bank_code": "0116",
+    "bic": "BSCHESMM",
+    "name": "BANCO POPULAR INDUSTRIAL, S.A.(EUROBANCO)",
+    "short_name": "POPULAR IND."
   }
 ]


### PR DESCRIPTION
Hello!

We are using IBAN numbers to extract the BIC to perform payments using a third party service and we ran into some issues with Banco Popular (an old spanish bank).

Long story short, Banco Popular was acquired by Banco Santander a few years ago and I now their bic code should be the one for Banco Santander instead.
I noticed that you auto-generate the spanish info from https://www.iban.es/, but I think their data for this specific case is outdated.

I've tested succesfully that overriding a code in the `manual_XX.json` file overrides the generated, so I created this small PR to override both bank codes for banco popular.