### PR TITLE
Add check sum for San Marino

### DIFF
--- a/schwifty/iban.py
+++ b/schwifty/iban.py
@@ -40,7 +40,8 @@ def code_length(spec: Dict, code_type: str) -> int:
 
 
 def add_bban_checksum(country_code: str, bban: str) -> str:
-    if country_code == "IT":
+    if country_code in ["IT", "SM"]:
+        # The IBAN of San Marino is covered by the Italian IBAN and uses the same checksum
         checksum = algorithms["IT:default"].compute(bban[1:])
         bban = checksum + bban[1:]
     elif country_code == "BE":


### PR DESCRIPTION
According to the Register of European Account Numbers (ECBS TR 201V3.9) (page 79), the Italian IBAN covers San Marino and so it also has a similar check digit.