### PR TITLE
feat: add bank of ireland to registry

### DIFF
--- a/schwifty/bank_registry/manual_ie.json
+++ b/schwifty/bank_registry/manual_ie.json
@@ -14,5 +14,13 @@
     "name": "J.P. Morgan Bank Luxembourg S.A. Dublin Branch",
     "short_name": "J.P. Morgan Bank Luxembourg S.A. Dublin Branch",
     "primary": true
+  },
+  {
+    "country_code": "IE",
+    "bic": "BOFIIE2D",
+    "bank_code": "BOFI",
+    "name": "Bank Of Ireland",
+    "short_name": "Bank Of Ireland",
+    "primary": true
   }
 ]


### PR DESCRIPTION
Hi there,
i came noticed that the bank of ireland was missing in the registry. So I took the liberty to add them.

The only question I got is if you like to maintain primary BICs with or without the `XXX` suffix, as there was already a mixture in the file for ireland