### PR TITLE
Update package URL's

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,10 @@
 name = schwifty
 author = Martin Domke
 author_email = mail@martindomke.net
-home_page = http://github.com/mdomke/schwifty
+url = http://github.com/mdomke/schwifty
+project_urls =
+    Documentation = https://schwifty.readthedocs.io/en/latest/
+    Changelog = https://github.com/mdomke/schwifty/blob/master/CHANGELOG.rst
 license = MIT
 summary = Validate/generate IBANs and BICs
 long_description= file: README.rst


### PR DESCRIPTION
`home_page` is an (undocumented?) alias for `url`, so use `url` instead (source: https://github.com/pypa/setuptools/blob/2582a8bc1a93d9876cf62d4f83ccb60a5110798c/setuptools/config/setupcfg.py#L469)

add `project_urls` which PyPI will render with nice icons on the side bar (example: https://pypi.org/project/django-htmx/)