### PR TITLE
Remove 'hacking' from tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ envlist = py{37,38,39},lint,lint-docs,fmt,mypy
 deps =
   pytest
   pytest-cov
-  hacking
 commands = pytest --cov {envsitepackagesdir}/schwifty {posargs} tests
 
 [testenv:lint]


### PR DESCRIPTION
'hacking' only exists to set up flake8, but that is in the `lint` testenv instead.