### PR TITLE
Fixed Hungary bank codes to be numeric

### DIFF
--- a/schwifty/bank_registry/generated_hu.json
+++ b/schwifty/bank_registry/generated_hu.json
@@ -3,7 +3,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "HUSTHUHB",
-    "bank_code": "HUST",
+    "bank_code": "100",
     "name": "Magyar \u00c1llamkincst\u00e1r K\u00f6zpont",
     "short_name": "Magyar \u00c1llamkincst\u00e1r K\u00f6zpont"
   },
@@ -11,7 +11,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "MKKBHUHB",
-    "bank_code": "MKKB",
+    "bank_code": "101",
     "name": "MKB Bank Nyrt. Szent Istv\u00e1n t\u00e9r",
     "short_name": "MKB Bank Nyrt. Szent Istv\u00e1n t\u00e9r"
   },
@@ -19,7 +19,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "OKHBHUHB",
-    "bank_code": "OKHB",
+    "bank_code": "102",
     "name": "K&H Bank Zrt. 242 P\u00e9cs",
     "short_name": "K&H Bank Zrt. 242 P\u00e9cs"
   },
@@ -27,7 +27,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "CIBHHUHB",
-    "bank_code": "CIBH",
+    "bank_code": "107",
     "name": "CIB Bank Zrt. K\u00f6zpont",
     "short_name": "CIB Bank Zrt. K\u00f6zpont"
   },
@@ -35,7 +35,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "CITIHUHX",
-    "bank_code": "CITI",
+    "bank_code": "108",
     "name": "Citibank Europe Plc. Mo-i Fi\u00f3ktelepe",
     "short_name": "Citibank Europe Plc. Mo-i Fi\u00f3ktelepe"
   },
@@ -43,7 +43,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "BACXHUHB",
-    "bank_code": "BACX",
+    "bank_code": "109",
     "name": "UniCredit Bank Hungary Zrt.",
     "short_name": "UniCredit Bank Hungary Zrt."
   },
@@ -51,7 +51,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "MANEHUHH",
-    "bank_code": "MANE",
+    "bank_code": "114",
     "name": "NHB N\u00f6veked\u00e9si Hitel Bank Szent Istv\u00e1n",
     "short_name": "NHB N\u00f6veked\u00e9si Hitel Bank Szent Istv\u00e1n"
   },
@@ -59,7 +59,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "TAKBHUHB",
-    "bank_code": "TAKB",
+    "bank_code": "115",
     "name": "MTB Zrt. K\u00f6zpont",
     "short_name": "MTB Zrt. K\u00f6zpont"
   },
@@ -67,7 +67,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "GIBAHUHB",
-    "bank_code": "GIBA",
+    "bank_code": "116",
     "name": "Erste Bank Zrt.",
     "short_name": "Erste Bank Zrt."
   },
@@ -75,7 +75,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "OTPVHUHB",
-    "bank_code": "OTPV",
+    "bank_code": "117",
     "name": "OTP Budapesti r., I. Alag\u00fat u.",
     "short_name": "OTP Budapesti r., I. Alag\u00fat u."
   },
@@ -83,7 +83,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "INTFBGSF",
-    "bank_code": "INTF",
+    "bank_code": "118",
     "name": "iCARD AD",
     "short_name": "iCARD AD"
   },
@@ -91,7 +91,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "UBRTHUHB",
-    "bank_code": "UBRT",
+    "bank_code": "120",
     "name": "Raiffeisen Bank Zrt. Budapesti Fi\u00f3k",
     "short_name": "Raiffeisen Bank Zrt. Budapesti Fi\u00f3k"
   },
@@ -99,7 +99,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "GNBAHUHB",
-    "bank_code": "GNBA",
+    "bank_code": "121",
     "name": "Gr\u00e1nit Bank Zrt.",
     "short_name": "Gr\u00e1nit Bank Zrt."
   },
@@ -107,7 +107,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "TRWIBEBB",
-    "bank_code": "TRWI",
+    "bank_code": "126",
     "name": "TransferWise Europe SA",
     "short_name": "TransferWise Europe SA"
   },
@@ -115,7 +115,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "MRKBHUHB",
-    "bank_code": "MRKB",
+    "bank_code": "128",
     "name": "MERKANTIL BANK Zrt.",
     "short_name": "MERKANTIL BANK Zrt."
   },
@@ -123,7 +123,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "BNPAHUHX",
-    "bank_code": "BNPA",
+    "bank_code": "131",
     "name": "BNP-Paribas Magyarorsz\u00e1gi fi\u00f3ktelepe",
     "short_name": "BNP-Paribas Magyarorsz\u00e1gi fi\u00f3ktelepe"
   },
@@ -131,7 +131,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "KODBHUHB",
-    "bank_code": "KODB",
+    "bank_code": "135",
     "name": "KDB Bank Eur\u00f3pa Zrt.",
     "short_name": "KDB Bank Eur\u00f3pa Zrt."
   },
@@ -139,7 +139,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "INGBHUHB",
-    "bank_code": "INGB",
+    "bank_code": "137",
     "name": "ING Bank N.V. Magyarorsz\u00e1gi Fi\u00f3ktelepe",
     "short_name": "ING Bank N.V. Magyarorsz\u00e1gi Fi\u00f3ktelepe"
   },
@@ -147,7 +147,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "COBAHUHX",
-    "bank_code": "COBA",
+    "bank_code": "142",
     "name": "COMMERZBANK ZRT.",
     "short_name": "COMMERZBANK ZRT."
   },
@@ -155,7 +155,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "KELRHUHBABC",
-    "bank_code": "KELR",
+    "bank_code": "144",
     "name": "KELER Zrt.",
     "short_name": "KELER Zrt."
   },
@@ -163,7 +163,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "HBIDHUHB",
-    "bank_code": "HBID",
+    "bank_code": "146",
     "name": "MFB Magyar Fejleszt\u00e9si Bank Zrt.",
     "short_name": "MFB Magyar Fejleszt\u00e9si Bank Zrt."
   },
@@ -171,7 +171,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "HEXIHUHB",
-    "bank_code": "HEXI",
+    "bank_code": "148",
     "name": "Eximbank Zrt.",
     "short_name": "Eximbank Zrt."
   },
@@ -179,7 +179,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "PAUALT22",
-    "bank_code": "PAUA",
+    "bank_code": "151",
     "name": "Paystrax UAB",
     "short_name": "Paystrax UAB"
   },
@@ -187,7 +187,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "HBWEHUHB",
-    "bank_code": "HBWE",
+    "bank_code": "162",
     "name": "MAGNET Bank",
     "short_name": "MAGNET Bank"
   },
@@ -195,7 +195,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "DEUTHU2B",
-    "bank_code": "DEUT",
+    "bank_code": "163",
     "name": "Deutsche Bank AG Magyarorsz\u00e1gi Fi\u00f3ktelep",
     "short_name": "Deutsche Bank AG Magyarorsz\u00e1gi Fi\u00f3ktelep"
   },
@@ -203,7 +203,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "MCBHHUHB",
-    "bank_code": "MCBH",
+    "bank_code": "167",
     "name": "Magyar Cetelem Bank Zrt.",
     "short_name": "Magyar Cetelem Bank Zrt."
   },
@@ -211,7 +211,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "FHJBHUHB",
-    "bank_code": "FHJB",
+    "bank_code": "168",
     "name": "Takar\u00e9k Jelz\u00e1logbank Nyrt",
     "short_name": "Takar\u00e9k Jelz\u00e1logbank Nyrt"
   },
@@ -219,7 +219,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "BKCHHUHB",
-    "bank_code": "BKCH",
+    "bank_code": "175",
     "name": "Bank of China (CEE) Zrt.",
     "short_name": "Bank of China (CEE) Zrt."
   },
@@ -227,7 +227,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "EHBBHUHS",
-    "bank_code": "EHBB",
+    "bank_code": "176",
     "name": "Sopron Bank ZRt K\u00f6zpont",
     "short_name": "Sopron Bank ZRt K\u00f6zpont"
   },
@@ -235,7 +235,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "OBKLHUHB",
-    "bank_code": "OBKL",
+    "bank_code": "184",
     "name": "OBERBANK Ag, Magyarorsz\u00e1gi fi\u00f3ktelep",
     "short_name": "OBERBANK Ag, Magyarorsz\u00e1gi fi\u00f3ktelep"
   },
@@ -243,7 +243,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "PARBHUHX",
-    "bank_code": "PARB",
+    "bank_code": "186",
     "name": "BNP Paribas Securities Services",
     "short_name": "BNP Paribas Securities Services"
   },
@@ -251,7 +251,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "BORGISRE",
-    "bank_code": "BORG",
+    "bank_code": "194",
     "name": "BORGUN hf.",
     "short_name": "BORGUN hf."
   },
@@ -259,7 +259,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "CLSBUS33",
-    "bank_code": "CLSB",
+    "bank_code": "196",
     "name": "CLS Bank International",
     "short_name": "CLS Bank International"
   },
@@ -267,7 +267,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "BKCHHUHH",
-    "bank_code": "BKCH",
+    "bank_code": "197",
     "name": "Bank of China Limited Mo-i Fi\u00f3ktelepe",
     "short_name": "Bank of China Limited Mo-i Fi\u00f3ktelepe"
   },
@@ -275,7 +275,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "OFSZHUHB",
-    "bank_code": "OFSZ",
+    "bank_code": "222",
     "name": "O.F.SZ. Zrt",
     "short_name": "O.F.SZ. Zrt"
   },
@@ -283,7 +283,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "BRELROBU",
-    "bank_code": "BREL",
+    "bank_code": "296",
     "name": "Libra Internet Bank S.A.",
     "short_name": "Libra Internet Bank S.A."
   },
@@ -291,7 +291,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "DTBAHUHB",
-    "bank_code": "DTBA",
+    "bank_code": "586",
     "name": "DUNA Takar\u00e9k Bank Zrt.",
     "short_name": "DUNA Takar\u00e9k Bank Zrt."
   },
@@ -299,7 +299,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "POLBHU22",
-    "bank_code": "POLB",
+    "bank_code": "612",
     "name": "Polg\u00e1ri Bank Zrt.",
     "short_name": "Polg\u00e1ri Bank Zrt."
   },
@@ -307,7 +307,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "FLTPHUHB",
-    "bank_code": "FLTP",
+    "bank_code": "880",
     "name": "Fundamenta-Lak\u00e1skassza Zrt.",
     "short_name": "Fundamenta-Lak\u00e1skassza Zrt."
   },
@@ -315,7 +315,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "OTPJHUHB",
-    "bank_code": "OTPJ",
+    "bank_code": "884",
     "name": "OTP Jelz\u00e1logbank Zrt.",
     "short_name": "OTP Jelz\u00e1logbank Zrt."
   },
@@ -323,7 +323,7 @@
     "country_code": "HU",
     "primary": true,
     "bic": "HUPOHUHB",
-    "bank_code": "HUPO",
+    "bank_code": "903",
     "name": "Postai Elsz\u00e1mol\u00f3 K\u00f6zpont",
     "short_name": "Postai Elsz\u00e1mol\u00f3 K\u00f6zpont"
   }

--- a/scripts/get_bank_registry_hu.py
+++ b/scripts/get_bank_registry_hu.py
@@ -23,13 +23,14 @@ def process():
                 bic_code = str(line[1].value).upper()
                 if bic_code not in yielded_bic_codes:
                     yielded_bic_codes.add(bic_code)
+                    bank_code = str(line[0].value)[:3]
                     bank_name = str(line[2].value)
 
                     yield {
                         "country_code": "HU",
                         "primary": True,
                         "bic": bic_code,
-                        "bank_code": bic_code[:4],
+                        "bank_code": bank_code,
                         "name": bank_name,
                         "short_name": bank_name,
                     }


### PR DESCRIPTION
Hello @mdomke,

I'm sorry, but I made a mistake in my previous PR with Hungarian bank codes #96, this PR corrects it. 

I've checked the Hungarian IBAN format https://bank.codes/iban/structure/hungary/, where bank codes are in `3n` format, which I've corrected in the generator script and generated valid bank_codes.