### PR TITLE
feat(app): added GR banks

### DIFF
--- a/schwifty/bank_registry/manual_gr.json
+++ b/schwifty/bank_registry/manual_gr.json
@@ -1,0 +1,179 @@
+[
+    {
+      "primary": true,
+      "name": "AEGEAN BALTIC BANK S.A.",
+      "short_name": "AEGEAN BALTIC BANK",
+      "bank_code": "056",
+      "bic": "AEBAGRAAXXX",
+      "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "ALPHA BANK S.A.",
+        "short_name": "ALPHA BANK",
+        "bank_code": "014",
+        "bic": "CRBAGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "ATTICA ΒΑΝΚ S.A.",
+        "short_name": "ATTICA ΒΑΝΚ",
+        "bank_code": "016",
+        "bic": "ATTIGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "BANK OF AMERICA EUROPE DESIGNATED ACTIVITY COMPANY - ATHENS BRANCH",
+        "short_name": "BANK OF AMERICA EUROPE DESIGNATED ACTIVITY COMPANY",
+        "bank_code": "081",
+        "bic": "BOFAGR2XXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "BANK OF CHINA (LUXEMBOURG) S.A. ATHENS BRANCH",
+        "short_name": "BANK OF CHINA",
+        "bank_code": "121",
+        "bic": "BKCHGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "BANK OF GREECE S.A.",
+        "short_name": "BANK OF GREECE",
+        "bank_code": "010",
+        "bic": "BNGRGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "BLACK SEA TRADE AND DEVELOPMENT BANK",
+        "short_name": "BLACK SEA TRADE AND DEVELOPMENT BANK",
+        "bank_code": "BSTD",
+        "bic": "BSTDGR2TXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "BNP PARIBAS SECURITIES SERVICES",
+        "short_name": "BNP PARIBAS SECURITIES SERVICES",
+        "bank_code": "039",
+        "bic": "PARBGRAXXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "CITIBANK EUROPE PLC (CEP)",
+        "short_name": "CITIBANK EUROPE PLC (CEP)",
+        "bank_code": "084",
+        "bic": "CITIGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "COOPERATIVE BANK OF DRAMA",
+        "short_name": "COOPERATIVE BANK OF DRAMA",
+        "bank_code": "088",
+        "bic": "STEOGR21XXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "ENEX CLEARING HOUSE S.A.",
+        "short_name": "ENEX CLEARING HOUSE",
+        "bank_code": "ENCH",
+        "bic": "ENCHGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "EUROBANK S.A.",
+        "short_name": "EUROBANK",
+        "bank_code": "026",
+        "bic": "ERBKGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "HSBC CONTINENTAL EUROPE GREECE",
+        "short_name": "HSBC CONTINENTAL EUROPE GREECE",
+        "bank_code": "071",
+        "bic": "MIDLGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "NATIONAL BANK OF GREECE S.A.",
+        "short_name": "NATIONAL BANK OF GREECE",
+        "bank_code": "011",
+        "bic": "ETHNGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "OPTIMA BANK S.A.",
+        "short_name": "OPTIMA BANK",
+        "bank_code": "034",
+        "bic": "IBOGGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "PANCRETA BANK S.A.",
+        "short_name": "PANCRETA BANK",
+        "bank_code": "087",
+        "bic": "STPGGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "PIRAEUS BANK S.A.",
+        "short_name": "PIRAEUS BANK",
+        "bank_code": "017",
+        "bic": "PIRBGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "PROCREDIT BANK (BULGARIA) EAD",
+        "short_name": "PROCREDIT BANK (BULGARIA) EAD",
+        "bank_code": "116",
+        "bic": "PRCBGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "T.C. ZIRAAT BANKASI A.S.",
+        "short_name": "T.C. ZIRAAT BANKASI A.S.",
+        "bank_code": "109",
+        "bic": "TCZBGRATXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "UNICREDIT BANK AG (HYPOVEREINSBANK) ATHENS",
+        "short_name": "UNICREDIT BANK AG (HYPOVEREINSBANK) ATHENS",
+        "bank_code": "072",
+        "bic": "HYVEGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "VIVA PAYMENT SERVICES SINGLE MEMBER S.A.",
+        "short_name": "VIVA PAYMENT SERVICES S.A.",
+        "bank_code": "VPAY",
+        "bic": "VPAYGRAAXXX",
+        "country_code": "GR"
+    },
+    {
+        "primary": true,
+        "name": "VIVABANK SINGLE MEMBER BANKING S.A",
+        "short_name": "VIVABANK SINGLE MEMBER BANKING",
+        "bank_code": "057",
+        "bic": "PRXBGRAA",
+        "country_code": "GR"
+    }
+]
+


### PR DESCRIPTION
Hello @mdomke!

As you already probably know, at [Plum](https://github.com/withplum) we've been using your library for some time. Since we need more banks, I'm adding support for GR banks to have them available through schwifty.

I have manually added these institutions and cross checked with [Wise](https://wise.com/us/swift-codes/countries/greece) and [Bank of Greece](https://www.bankofgreece.gr/) for each bank's bic, bank_code and names (name and short_name).

Let me know if you need anything!