### PR TITLE
feat: Added file and bank info for Portuguese banks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 htmlcov/
 .coverage
 test-results.xml
+.python-version

--- a/schwifty/bank_registry/manual_pt.json
+++ b/schwifty/bank_registry/manual_pt.json
@@ -1,0 +1,106 @@
+[
+  {
+    "primary": true,
+    "name": "CAIXA GERAL DE DEPOSITOS SA",
+    "short_name": "CAIXA GERAL DE DEPOSITOS",
+    "bank_code": "0035",
+    "bic": "CGDIPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "NOVO BANCO SA",
+    "short_name": "NOVO BANCO",
+    "bank_code": "0007",
+    "bic": "CGDIPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANCO BPI SA",
+    "short_name": "BANCO BPI",
+    "bank_code": "0010",
+    "bic": "BBPIPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANCO SANTANDER TOTTA SA",
+    "short_name": "BANCO SANTANDER TOTTA",
+    "bank_code": "0018",
+    "bic": "TOTAPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANCO BILBAO VIZCAYA ARGENTARIA S.A. - SUCURSAL EM PORTUGAL",
+    "short_name": "BANCO BILBAO VIZCAYA ARGENTARIA",
+    "bank_code": "0019",
+    "bic": "BBVAPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANCO ACTIVOBANK SA",
+    "short_name": "BANCO ACTIVOBANK",
+    "bank_code": "0023",
+    "bic": "ACTVPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANCO COMERCIAL PORTUGUES SA",
+    "short_name": "BANCO COMERCIAL PORTUGUES",
+    "bank_code": "0033",
+    "bic": "BCOMPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "CAIXA ECONOMICA MONTEPIO GERAL CAIXA ECONOMICA BANCARIA SA",
+    "short_name": "CAIXA ECONOMICA MONTEPIO GERAL CAIXA ECONOMICA BANCARIA",
+    "bank_code": "0036",
+    "bic": "MPIOPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "CAIXA CENTRAL - CAIXA CENTRAL DE CREDITO AGRICOLA MUTUO CRL",
+    "short_name": "CREDITO AGRICOLA",
+    "bank_code": "0045",
+    "bic": "CCCMPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANCO BIC PORTUGUES SA",
+    "short_name": "BANCO BIC PORTUGUES",
+    "bank_code": "0079",
+    "bic": "BPNPPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANCO ATLANTICO EUROPA SA",
+    "short_name": "BANCO ATLANTICO EUROPA",
+    "bank_code": "0189",
+    "bic": "BAPAPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANCO CTT SA",
+    "short_name": "BANCO CTT",
+    "bank_code": "0193",
+    "bic": "CTTVPTPL",
+    "country_code": "PT"
+  },
+  {
+    "primary": true,
+    "name": "BANKINTER SA - SUCURSAL EM PORTUGAL",
+    "short_name": "BANKINTER",
+    "bank_code": "0269",
+    "bic": "BKBKPTPL",
+    "country_code": "PT"
+  }
+]


### PR DESCRIPTION
The banks added were retrieved based on the IBANs of users for which we failed to retrieve a BIC. The data were acquire from this [website](https://www.ibancalculator.com/).