### PR TITLE
fix: Correct bank codes for Cypriot banks

### DIFF
--- a/schwifty/bank_registry/manual_cy.json
+++ b/schwifty/bank_registry/manual_cy.json
@@ -35,7 +35,7 @@
         "primary": true,
         "name": "ASTROBANK PUBLIC COMPANY LIMITED",
         "short_name": "ASTROBANK PUBLIC COMPANY",
-        "bank_code": "PIRB",
+        "bank_code": "008",
         "bic": "PIRBCY2NXXX",
         "country_code": "CY"
     },   
@@ -59,7 +59,7 @@
         "primary": true,
         "name": "BANK OF CYPRUS PUBLIC COMPANY LIMITED",
         "short_name": "BANK OF CYPRUS PUBLIC COMPANY",
-        "bank_code": "BCYP",
+        "bank_code": "002",
         "bic": "BCYPCY2NXXX",
         "country_code": "CY"
     },   
@@ -179,7 +179,7 @@
         "primary": true,
         "name": "HELLENIC BANK PUBLIC COMPANY LTD.",
         "short_name": "HELLENIC BANK PUBLIC COMPANY",
-        "bank_code": "HEBA",
+        "bank_code": "005",
         "bic": "HEBACY2NXXX",
         "country_code": "CY"
     },  


### PR DESCRIPTION
Fix bank codes for the following banks:
- ASTROBANK PUBLIC COMPANY LIMITED
- BANK OF CYPRUS PUBLIC COMPANY LIMITED
- HELLENIC BANK PUBLIC COMPANY LTD