### PR TITLE
fix: Correct bank code for Viva Payment

### DIFF
--- a/schwifty/bank_registry/manual_gr.json
+++ b/schwifty/bank_registry/manual_gr.json
@@ -163,7 +163,7 @@
         "primary": true,
         "name": "VIVA PAYMENT SERVICES SINGLE MEMBER S.A.",
         "short_name": "VIVA PAYMENT SERVICES S.A.",
-        "bank_code": "VPAY",
+        "bank_code": "701",
         "bic": "VPAYGRAAXXX",
         "country_code": "GR"
     },


### PR DESCRIPTION
Fix Viva payment bank code information in the manually curated gr file.