### PR TITLE
Add norwegian bank registry

### DIFF
--- a/schwifty/bank_registry/generated_no.json
+++ b/schwifty/bank_registry/generated_no.json
@@ -1,0 +1,18370 @@
+[
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0500",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0519",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0520",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0521",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0522",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0525",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0529",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0530",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0531",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0532",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0533",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0534",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0535",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0536",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0537",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0538",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0539",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0540",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0542",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0543",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0544",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0545",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0546",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0547",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0570",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0571",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0573",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0574",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0576",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0577",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0578",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0579",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "0582",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1000",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1010",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1014",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "EIDSNO21",
+    "bank_code": "1020",
+    "name": "Eidsberg Sparebank",
+    "short_name": "Eidsberg Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "EIDSNO21",
+    "bank_code": "1029",
+    "name": "Eidsberg Sparebank",
+    "short_name": "Eidsberg Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RYGSNO21",
+    "bank_code": "1030",
+    "name": "Sparebank1 \u00d8stfold Akershus",
+    "short_name": "Sparebank1 \u00d8stfold Akershus"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1040",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "MASPNO21",
+    "bank_code": "1050",
+    "name": "Marker Sparebank",
+    "short_name": "Marker Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "MASPNO21",
+    "bank_code": "1051",
+    "name": "Marker Sparebank",
+    "short_name": "Marker Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1061",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1064",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1070",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RYGSNO21",
+    "bank_code": "1080",
+    "name": "Sparebank1 \u00d8stfold Akershus",
+    "short_name": "Sparebank1 \u00d8stfold Akershus"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RYGSNO21",
+    "bank_code": "1081",
+    "name": "Sparebank1 \u00d8stfold Akershus",
+    "short_name": "Sparebank1 \u00d8stfold Akershus"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RYGSNO21",
+    "bank_code": "1082",
+    "name": "Sparebank1 \u00d8stfold Akershus",
+    "short_name": "Sparebank1 \u00d8stfold Akershus"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RYGSNO21",
+    "bank_code": "1083",
+    "name": "Sparebank1 \u00d8stfold Akershus",
+    "short_name": "Sparebank1 \u00d8stfold Akershus"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RYGSNO21",
+    "bank_code": "1085",
+    "name": "Sparebank1 \u00d8stfold Akershus",
+    "short_name": "Sparebank1 \u00d8stfold Akershus"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1090",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1097",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ASKSNO21",
+    "bank_code": "1100",
+    "name": "Askim og Spydeberg Sparebank",
+    "short_name": "Askim og Spydeberg Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ASKSNO21",
+    "bank_code": "1101",
+    "name": "Askim og Spydeberg Sparebank",
+    "short_name": "Askim og Spydeberg Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BRGPNO21",
+    "bank_code": "1105",
+    "name": "Berg Sparebank",
+    "short_name": "Berg Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1111",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1121",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ASKSNO21",
+    "bank_code": "1135",
+    "name": "Askim og Spydeberg Sparebank",
+    "short_name": "Askim og Spydeberg Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ASKSNO21",
+    "bank_code": "1139",
+    "name": "Askim og Spydeberg Sparebank",
+    "short_name": "Askim og Spydeberg Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TRSPNO21",
+    "bank_code": "1140",
+    "name": "Tr\u00f8gstad Sparebank",
+    "short_name": "Tr\u00f8gstad Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1145",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1150",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1160",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1200",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1201",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1202",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1203",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1204",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1206",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1207",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1208",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1210",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1211",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1212",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1213",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1214",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1221",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1224",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1225",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1226",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1227",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1228",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1229",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1230",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1231",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1240",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1250",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1251",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "CULTNOK1",
+    "bank_code": "1254",
+    "name": "Cultura Sparebank",
+    "short_name": "Cultura Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1260",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1261",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1262",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LISTNO21",
+    "bank_code": "1269",
+    "name": "Romerike Sparebank",
+    "short_name": "Romerike Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "AUSNNO21",
+    "bank_code": "1271",
+    "name": "Aurskog Sparebank",
+    "short_name": "Aurskog Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1275",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HOLLNO21",
+    "bank_code": "1280",
+    "name": "H\u00f8land og Setskog Sparebank",
+    "short_name": "H\u00f8land og Setskog Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LISTNO21",
+    "bank_code": "1286",
+    "name": "Romerike Sparebank",
+    "short_name": "Romerike Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1295",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "STMMNO21",
+    "bank_code": "1310",
+    "name": "Str\u00f8mmen Sparebank",
+    "short_name": "Str\u00f8mmen Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1315",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LISTNO21",
+    "bank_code": "1321",
+    "name": "Romerike Sparebank",
+    "short_name": "Romerike Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1335",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HOLLNO21",
+    "bank_code": "1338",
+    "name": "H\u00f8land og Setskog Sparebank",
+    "short_name": "H\u00f8land og Setskog Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SWEDNOKK",
+    "bank_code": "1430",
+    "name": "Swedbank Norge",
+    "short_name": "Swedbank Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SWEDNOKK",
+    "bank_code": "1431",
+    "name": "Swedbank Oslo",
+    "short_name": "Swedbank Oslo"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "JERNNO21",
+    "bank_code": "1440",
+    "name": "Jernbanepersonalets sparebank",
+    "short_name": "Jernbanepersonalets sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TELENO21",
+    "bank_code": "1450",
+    "name": "Oslofjord Sparebank ",
+    "short_name": "Oslofjord Sparebank "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1500",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1501",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1502",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1503",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1504",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1505",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1506",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1507",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1508",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1509",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1514",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1515",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1516",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1517",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1518",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1519",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1520",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1521",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1528",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1532",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1537",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1542",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1550",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1551",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1552",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1554",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1559",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1560",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1563",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1564",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1565",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1566",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1567",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1568",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1578",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1580",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1582",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1586",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1587",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1588",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1590",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1591",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1593",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1594",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1595",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1600",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1601",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1602",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1603",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1604",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1605",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1606",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1607",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1609",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1612",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1613",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1614",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1615",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1617",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1619",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1620",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1621",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1622",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1623",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1624",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1626",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1627",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1628",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1629",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1632",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1633",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1636",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1637",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1638",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1640",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1641",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1643",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1644",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1645",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1654",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1660",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1674",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1683",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1684",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1697",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1698",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1700",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BIENNOK1",
+    "bank_code": "1720",
+    "name": "Bien Sparebank ASA",
+    "short_name": "Bien Sparebank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1730",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1800",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1801",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1802",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1803",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1810",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1813",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1815",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1817",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1819",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1820",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1822",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1829",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GRUENO21",
+    "bank_code": "1830",
+    "name": "Grue Sparebank",
+    "short_name": "Grue Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1840",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1850",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1865",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1868",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ODASNO21",
+    "bank_code": "1870",
+    "name": "Odal Sparebank",
+    "short_name": "Odal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ODASNO21",
+    "bank_code": "1871",
+    "name": "Odal Sparebank",
+    "short_name": "Odal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "1875",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TOSPNO21",
+    "bank_code": "1885",
+    "name": "Tolga-Os Sparebank",
+    "short_name": "Tolga-Os Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TOSPNO21",
+    "bank_code": "1886",
+    "name": "Tolga-Os Sparebank",
+    "short_name": "Tolga-Os Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1890",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1895",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1904",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1913",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "1917",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2000",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2002",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2003",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2005",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2010",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RIRINO21",
+    "bank_code": "2020",
+    "name": "Sparebank 1 Ringerike Hadeland",
+    "short_name": "Sparebank 1 Ringerike Hadeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RIRINO21",
+    "bank_code": "2030",
+    "name": "Sparebank 1 Ringerike Hadeland",
+    "short_name": "Sparebank 1 Ringerike Hadeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TOTENO21",
+    "bank_code": "2050",
+    "name": "Totens Sparebank",
+    "short_name": "Totens Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TOTENO21",
+    "bank_code": "2051",
+    "name": "Totens Sparebank",
+    "short_name": "Totens Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2065",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2070",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2073",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2075",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2081",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LOSKNO21",
+    "bank_code": "2085",
+    "name": "Sparebank 1 Lom og Sj\u00e5k",
+    "short_name": "Sparebank 1 Lom og Sj\u00e5k"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2090",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SGFSNO21",
+    "bank_code": "2095",
+    "name": "Sparebank 1 Gudbrandsdal",
+    "short_name": "Sparebank 1 Gudbrandsdal"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2100",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2105",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2120",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SGFSNO21",
+    "bank_code": "2125",
+    "name": "Sparebank 1 Gudbrandsdal",
+    "short_name": "Sparebank 1 Gudbrandsdal"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAALNO21",
+    "bank_code": "2135",
+    "name": "Sparebank 1 Hallingdal Valdres",
+    "short_name": "Sparebank 1 Hallingdal Valdres"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ETSPNO21",
+    "bank_code": "2140",
+    "name": "Etnedal Sparebank",
+    "short_name": "Etnedal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VESLNO21",
+    "bank_code": "2146",
+    "name": "Valdres Sparebank",
+    "short_name": "Valdres Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VESLNO21",
+    "bank_code": "2153",
+    "name": "Valdres Sparebank",
+    "short_name": "Valdres Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VESLNO21",
+    "bank_code": "2154",
+    "name": "Valdres Sparebank",
+    "short_name": "Valdres Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2200",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2201",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2207",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2212",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2220",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2221",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2222",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2223",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NEPRNO21",
+    "bank_code": "2230",
+    "name": "Skue Sparebank",
+    "short_name": "Skue Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2240",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2241",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2245",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2250",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2260",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2261",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2270",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RIRINO21",
+    "bank_code": "2280",
+    "name": "Sparebank 1 Ringerike Hadeland",
+    "short_name": "Sparebank 1 Ringerike Hadeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RIRINO21",
+    "bank_code": "2281",
+    "name": "Sparebank 1 Ringerike Hadeland",
+    "short_name": "Sparebank 1 Ringerike Hadeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2291",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2300",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2310",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2318",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2319",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAALNO21",
+    "bank_code": "2320",
+    "name": "Sparebank 1 Hallingdal Valdres",
+    "short_name": "Sparebank 1 Hallingdal Valdres"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAALNO21",
+    "bank_code": "2322",
+    "name": "Sparebank 1 Hallingdal Valdres",
+    "short_name": "Sparebank 1 Hallingdal Valdres"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAALNO21",
+    "bank_code": "2324",
+    "name": "Sparebank 1 Hallingdal Valdres",
+    "short_name": "Sparebank 1 Hallingdal Valdres"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAALNO21",
+    "bank_code": "2325",
+    "name": "Sparebank 1 Hallingdal Valdres",
+    "short_name": "Sparebank 1 Hallingdal Valdres"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAALNO21",
+    "bank_code": "2329",
+    "name": "Sparebank 1 Hallingdal Valdres",
+    "short_name": "Sparebank 1 Hallingdal Valdres"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NEPRNO21",
+    "bank_code": "2333",
+    "name": "Skue Sparebank",
+    "short_name": "Skue Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2335",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2345",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "2346",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NEPRNO21",
+    "bank_code": "2351",
+    "name": "Skue Sparebank",
+    "short_name": "Skue Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NEPRNO21",
+    "bank_code": "2352",
+    "name": "Skue Sparebank",
+    "short_name": "Skue Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2356",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2361",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2364",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAALNO21",
+    "bank_code": "2367",
+    "name": "Sparebank 1 Hallingdal Valdres",
+    "short_name": "Sparebank 1 Hallingdal Valdres"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2372",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2375",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2378",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2400",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2401",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2410",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2420",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2440",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2442",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2448",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2450",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2460",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2467",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2470",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2475",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2480",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2481",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2489",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2490",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ANBUNO21",
+    "bank_code": "2500",
+    "name": "Andebu Sparebank",
+    "short_name": "Andebu Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ANBUNO21",
+    "bank_code": "2503",
+    "name": "Andebu Sparebank",
+    "short_name": "Andebu Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2505",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LABRNOB1",
+    "bank_code": "2510",
+    "name": "Larvikbanken",
+    "short_name": "Larvikbanken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2515",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2520",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2525",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2530",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2535",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2540",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2544",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2545",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2551",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2557",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2560",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2563",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2582",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BLSPNO21",
+    "bank_code": "2601",
+    "name": "Skagerrak Sparebank",
+    "short_name": "Skagerrak Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BLSPNO21",
+    "bank_code": "2606",
+    "name": "Skagerrak Sparebank",
+    "short_name": "Skagerrak Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2610",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TINNNO21",
+    "bank_code": "2620",
+    "name": "Tinn Sparebank",
+    "short_name": "Tinn Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TINNNO21",
+    "bank_code": "2621",
+    "name": "Tinn Sparebank",
+    "short_name": "Tinn Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BSPANO21",
+    "bank_code": "2630",
+    "name": "Sparebanken DIN",
+    "short_name": "Sparebanken DIN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BSPANO21",
+    "bank_code": "2632",
+    "name": "Sparebanken DIN",
+    "short_name": "Sparebanken DIN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DRANNO21",
+    "bank_code": "2635",
+    "name": "Drangedal Sparebank",
+    "short_name": "Drangedal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DRANNO21",
+    "bank_code": "2639",
+    "name": "Drangedal Sparebank",
+    "short_name": "Drangedal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2646",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2650",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BLSPNO21",
+    "bank_code": "2655",
+    "name": "Skagerrak Sparebank",
+    "short_name": "Skagerrak Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BLSPNO21",
+    "bank_code": "2656",
+    "name": "Skagerrak Sparebank",
+    "short_name": "Skagerrak Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2660",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2665",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "2670",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2675",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2680",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2685",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2694",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HJARNO21",
+    "bank_code": "2699",
+    "name": "Hjartdal og Gransherad Sparebank",
+    "short_name": "Hjartdal og Gransherad Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2704",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2705",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2708",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BSPANO21",
+    "bank_code": "2711",
+    "name": "Sparebanken DIN",
+    "short_name": "Sparebanken DIN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2714",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "2717",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2800",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2801",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2803",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2809",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2811",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2818",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2819",
+    "name": "Sparebanken S\u00f8r ",
+    "short_name": "Sparebanken S\u00f8r "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2821",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2826",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2835",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2840",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LILLNO21",
+    "bank_code": "2850",
+    "name": "Lillesands Sparebank",
+    "short_name": "Lillesands Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2860",
+    "name": "Sparebanken S\u00f8r ",
+    "short_name": "Sparebanken S\u00f8r "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BISNNO21",
+    "bank_code": "2880",
+    "name": "Birkenes Sparebank",
+    "short_name": "Birkenes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BISNNO21",
+    "bank_code": "2881",
+    "name": "Birkenes Sparebank",
+    "short_name": "Birkenes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VSPANO21",
+    "bank_code": "2890",
+    "name": "Valle Sparebank",
+    "short_name": "Valle Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ARENNO21",
+    "bank_code": "2895",
+    "name": "Agder Sparebank",
+    "short_name": "Agder Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2898",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "EVJENO21",
+    "bank_code": "2901",
+    "name": "Evje og Hornnes Sparebank",
+    "short_name": "Evje og Hornnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "EVJENO21",
+    "bank_code": "2902",
+    "name": "Evje og Hornnes Sparebank",
+    "short_name": "Evje og Hornnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2904",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GJSPNO21",
+    "bank_code": "2907",
+    "name": "Agder Sparebank",
+    "short_name": "Agder Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GJSPNO21",
+    "bank_code": "2908",
+    "name": "Agder Sparebank",
+    "short_name": "Agder Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2913",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2920",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2926",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GJSPNO21",
+    "bank_code": "2938",
+    "name": "Agder Sparebank",
+    "short_name": "Agder Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "2949",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3000",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3001",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3006",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3023",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FLEKNO21",
+    "bank_code": "3030",
+    "name": "Flekkefjord Sparebank",
+    "short_name": "Flekkefjord Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3040",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3050",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSKNO21",
+    "bank_code": "3060",
+    "name": "Spareskillingsbanken",
+    "short_name": "Spareskillingsbanken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3070",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3075",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KVIDNO21",
+    "bank_code": "3080",
+    "name": "Kvinesdal Sparebank",
+    "short_name": "Kvinesdal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3085",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOGSNO21",
+    "bank_code": "3090",
+    "name": "S\u00f8gne og Greipstad Sparebank",
+    "short_name": "S\u00f8gne og Greipstad Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3095",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3100",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3108",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KVIDNO21",
+    "bank_code": "3111",
+    "name": "Kvinesdal Sparebank",
+    "short_name": "Kvinesdal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3114",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KVIDNO21",
+    "bank_code": "3117",
+    "name": "Kvinesdal Sparebank",
+    "short_name": "Kvinesdal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3123",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3126",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3129",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3132",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3138",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3141",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3144",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "3148",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3180",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3185",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3201",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3202",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3204",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3205",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3206",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3207",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3208",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3209",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3210",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3211",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3212",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3213",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3223",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3224",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3227",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3230",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAUGNO21",
+    "bank_code": "3240",
+    "name": "Haugesund Sparebank",
+    "short_name": "Haugesund Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAUGNO21",
+    "bank_code": "3241",
+    "name": "Haugesund Sparebank",
+    "short_name": "Haugesund Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAUGNO21",
+    "bank_code": "3242",
+    "name": "Haugesund Sparebank",
+    "short_name": "Haugesund Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAUGNO21",
+    "bank_code": "3243",
+    "name": "Haugesund Sparebank",
+    "short_name": "Haugesund Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAUGNO21",
+    "bank_code": "3244",
+    "name": "Haugesund Sparebank",
+    "short_name": "Haugesund Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAUGNO21",
+    "bank_code": "3247",
+    "name": "Haugesund Sparebank",
+    "short_name": "Haugesund Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3250",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SASKNO22",
+    "bank_code": "3260",
+    "name": "Sandnes Sparebank",
+    "short_name": "Sandnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SASKNO22",
+    "bank_code": "3261",
+    "name": "Sandnes Sparebank",
+    "short_name": "Sandnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SASKNO22",
+    "bank_code": "3264",
+    "name": "Sandnes Sparebank",
+    "short_name": "Sandnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SASKNO22",
+    "bank_code": "3265",
+    "name": "Sandnes Sparebank",
+    "short_name": "Sandnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SASKNO22",
+    "bank_code": "3268",
+    "name": "Sandnes Sparebank",
+    "short_name": "Sandnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3270",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3280",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KLEPNO21",
+    "bank_code": "3290",
+    "name": "J\u00e6ren Sparebank",
+    "short_name": "J\u00e6ren Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3295",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3305",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3310",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3315",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KLEPNO21",
+    "bank_code": "3325",
+    "name": "J\u00e6ren Sparebank",
+    "short_name": "J\u00e6ren Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3330",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3332",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3333",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3335",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3340",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3344",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3347",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3350",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HJELNO21",
+    "bank_code": "3353",
+    "name": "Hjelmeland Sparebank",
+    "short_name": "Hjelmeland Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SKAANO21",
+    "bank_code": "3361",
+    "name": "Skudenes & Aakra Sparebank",
+    "short_name": "Skudenes & Aakra Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3364",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3373",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3409",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3411",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3412",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3413",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3414",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3415",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3416",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3417",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3418",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "FANANOB1",
+    "bank_code": "3419",
+    "name": "Fana Sparebank",
+    "short_name": "Fana Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3420",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3450",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3460",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3470",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOSKNO21",
+    "bank_code": "3480",
+    "name": "Voss Sparebank",
+    "short_name": "Voss Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOSKNO21",
+    "bank_code": "3485",
+    "name": "Voss Sparebank",
+    "short_name": "Voss Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3490",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3492",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3495",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3500",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3506",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3520",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TYSSNO21",
+    "bank_code": "3525",
+    "name": "Tysnes Sparebank",
+    "short_name": "Tysnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TYSSNO21",
+    "bank_code": "3529",
+    "name": "Tysnes Sparebank",
+    "short_name": "Tysnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3530",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "3535",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3540",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ETNENO21",
+    "bank_code": "3543",
+    "name": "Sparebanken Vest Etne",
+    "short_name": "Sparebanken Vest Etne"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3546",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3562",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3565",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3569",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOSKNO21",
+    "bank_code": "3578",
+    "name": "Voss Sparebank",
+    "short_name": "Voss Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3602",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3604",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3605",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3606",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3607",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3608",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3609",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3610",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3611",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3612",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3613",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3615",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3616",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3621",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3622",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3623",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3624",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3625",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3626",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3628",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3630",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3631",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3632",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3633",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3635",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3636",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3637",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3638",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3640",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3642",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3643",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3645",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3646",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3647",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3649",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3650",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3652",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3658",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3670",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3700",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3703",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3704",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3705",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3706",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3707",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3708",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3709",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3710",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3720",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "IDRENO21",
+    "bank_code": "3730",
+    "name": "Sogn Sparebank",
+    "short_name": "Sogn Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "IDRENO21",
+    "bank_code": "3739",
+    "name": "Sogn Sparebank",
+    "short_name": "Sogn Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3740",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3741",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "IDRENO21",
+    "bank_code": "3745",
+    "name": "Sogn Sparebank",
+    "short_name": "Sogn Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3760",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3770",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3775",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3776",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3781",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LUSKNO21",
+    "bank_code": "3785",
+    "name": "Luster Sparebank",
+    "short_name": "Luster Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3790",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3795",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "IDRENO21",
+    "bank_code": "3800",
+    "name": "Sogn Sparebank",
+    "short_name": "Sogn Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3805",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3816",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3817",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3820",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3829",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3832",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3835",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3836",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3837",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "IDRENO21",
+    "bank_code": "3838",
+    "name": "Sogn Sparebank",
+    "short_name": "Sogn Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3841",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3845",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3847",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3848",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3853",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "3855",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3880",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOFJNO22",
+    "bank_code": "3890",
+    "name": "Sparebanken Sogn og Fjordane",
+    "short_name": "Sparebanken Sogn og Fjordane"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3900",
+    "name": "Sparebanken M\u00f8re",
+    "short_name": "Sparebanken M\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3901",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3902",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3904",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3905",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3906",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3907",
+    "name": "Sparebanken M\u00f8re",
+    "short_name": "Sparebanken M\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3909",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3910",
+    "name": "Sparebanken M\u00f8re",
+    "short_name": "Sparebanken M\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3920",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3930",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3931",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3932",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3933",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3935",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3936",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3938",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3941",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "3943",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3960",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3963",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3969",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3971",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3972",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3974",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "3980",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOLDNO21",
+    "bank_code": "3991",
+    "name": "SpareBank 1 S\u00f8re Sunnm\u00f8re",
+    "short_name": "SpareBank 1 S\u00f8re Sunnm\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOLDNO21",
+    "bank_code": "3992",
+    "name": "SpareBank 1 S\u00f8re Sunnm\u00f8re ",
+    "short_name": "SpareBank 1 S\u00f8re Sunnm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOLDNO21",
+    "bank_code": "3993",
+    "name": "SpareBank 1 S\u00f8re Sunnm\u00f8re",
+    "short_name": "SpareBank 1 S\u00f8re Sunnm\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOLDNO21",
+    "bank_code": "3994",
+    "name": "SpareBank 1 S\u00f8re Sunnm\u00f8re",
+    "short_name": "SpareBank 1 S\u00f8re Sunnm\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOLDNO21",
+    "bank_code": "3995",
+    "name": "SpareBank 1 S\u00f8re Sunnm\u00f8re",
+    "short_name": "SpareBank 1 S\u00f8re Sunnm\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOLDNO21",
+    "bank_code": "3997",
+    "name": "SpareBank 1 S\u00f8re Sunnm\u00f8re",
+    "short_name": "SpareBank 1 S\u00f8re Sunnm\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOLDNO21",
+    "bank_code": "3998",
+    "name": "SpareBank 1 S\u00f8re Sunnm\u00f8re",
+    "short_name": "SpareBank 1 S\u00f8re Sunnm\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4005",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4006",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4020",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "4025",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4030",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SUSANO21",
+    "bank_code": "4035",
+    "name": "Sunndal Sparebank",
+    "short_name": "Sunndal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "4040",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4045",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4050",
+    "name": "Sparebanken M\u00f8re",
+    "short_name": "Sparebanken M\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4056",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ORKONO21",
+    "bank_code": "4060",
+    "name": "\u00d8rskog Sparebank",
+    "short_name": "\u00d8rskog Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4065",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4068",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BFHSNO21",
+    "bank_code": "4075",
+    "name": "Romsdal Sparebank",
+    "short_name": "Romsdal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4087",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "4090",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4093",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BFHSNO21",
+    "bank_code": "4100",
+    "name": "Romsdal Sparebank",
+    "short_name": "Romsdal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BFHSNO21",
+    "bank_code": "4106",
+    "name": "Romsdal Sparebank",
+    "short_name": "Romsdal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4108",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RINDNO21",
+    "bank_code": "4111",
+    "name": "Rindal Sparebank",
+    "short_name": "Rindal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4120",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORVNO21",
+    "bank_code": "4130",
+    "name": "SpareBank 1 Nordm\u00f8re ",
+    "short_name": "SpareBank 1 Nordm\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPARNO22",
+    "bank_code": "4137",
+    "name": "Sparebanken M\u00f8re ",
+    "short_name": "Sparebanken M\u00f8re "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VOLDNO21",
+    "bank_code": "4168",
+    "name": "SpareBank 1 S\u00f8re Sunnm\u00f8re",
+    "short_name": "SpareBank 1 S\u00f8re Sunnm\u00f8re"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4200",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4201",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4202",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4208",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4209",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4212",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4213",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4214",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4215",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4218",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4219",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4223",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4224",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4227",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "MELHNO21",
+    "bank_code": "4230",
+    "name": "Melhus Sparebank",
+    "short_name": "Melhus Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4240",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4241",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4242",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4243",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4244",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4245",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4250",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "OKDLNO21",
+    "bank_code": "4260",
+    "name": "Orkla Sparebank",
+    "short_name": "Orkla Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "OKDLNO21",
+    "bank_code": "4261",
+    "name": "Orkla Sparebank",
+    "short_name": "Orkla Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "OPPDNO21",
+    "bank_code": "4266",
+    "name": "Oppdalsbanken",
+    "short_name": "Oppdalsbanken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "OKDLNO21",
+    "bank_code": "4270",
+    "name": "Orkla Sparebank",
+    "short_name": "Orkla Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RORBNO21",
+    "bank_code": "4280",
+    "name": "R\u00f8rosBanken",
+    "short_name": "R\u00f8rosBanken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RORBNO21",
+    "bank_code": "4281",
+    "name": "R\u00f8rosBanken",
+    "short_name": "R\u00f8rosBanken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SELSNO21",
+    "bank_code": "4285",
+    "name": "Selbu Sparebank",
+    "short_name": "Selbu Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ORLANO21",
+    "bank_code": "4290",
+    "name": "\u00d8rland Sparebank",
+    "short_name": "\u00d8rland Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ORLANO21",
+    "bank_code": "4291",
+    "name": "\u00d8rland Sparebank",
+    "short_name": "\u00d8rland Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BJUGNO21",
+    "bank_code": "4295",
+    "name": "Bjugn Sparebank",
+    "short_name": "Bjugn Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HEMNNO21",
+    "bank_code": "4312",
+    "name": "Hemne Sparebank",
+    "short_name": "Hemne Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HEMNNO21",
+    "bank_code": "4313",
+    "name": "Hemne Sparebank",
+    "short_name": "Hemne Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4319",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SOKNNO21",
+    "bank_code": "4333",
+    "name": "Soknedal Sparebank",
+    "short_name": "Soknedal Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "STADNO21",
+    "bank_code": "4336",
+    "name": "Stadsbygd Sparebank",
+    "short_name": "Stadsbygd Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4342",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "AFJONO21",
+    "bank_code": "4345",
+    "name": "\u00c5fjord Sparebank",
+    "short_name": "\u00c5fjord Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4349",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4352",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HALTNO21",
+    "bank_code": "4355",
+    "name": "Haltdalen Sparebank",
+    "short_name": "Haltdalen Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HALTNO21",
+    "bank_code": "4356",
+    "name": "Haltdalen Sparebank",
+    "short_name": "Haltdalen Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KLBUNO21",
+    "bank_code": "4358",
+    "name": "Nidaros Sparebank",
+    "short_name": "Nidaros Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4360",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4361",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4400",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4401",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4409",
+    "name": "SpareBank 1 SMN ",
+    "short_name": "SpareBank 1 SMN "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4410",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4415",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4420",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4421",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4422",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4425",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4435",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4440",
+    "name": "SpareBank 1 SMN ",
+    "short_name": "SpareBank 1 SMN "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GRONNO21",
+    "bank_code": "4448",
+    "name": "Grong Sparebank",
+    "short_name": "Grong Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GRONNO21",
+    "bank_code": "4449",
+    "name": "Grong Sparebank",
+    "short_name": "Grong Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4451",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4459",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4464",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HESPNOB1",
+    "bank_code": "4465",
+    "name": "Hegra Sparebank",
+    "short_name": "Hegra Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4466",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4467",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4468",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HESPNOB1",
+    "bank_code": "4469",
+    "name": "Hegra Sparebank",
+    "short_name": "Hegra Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4470",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4471",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4472",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4473",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4474",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4476",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4480",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GRONNO21",
+    "bank_code": "4481",
+    "name": "Grong Sparebank",
+    "short_name": "Grong Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4482",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "AASANO21",
+    "bank_code": "4484",
+    "name": "Aasen Sparebank",
+    "short_name": "Aasen Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4500",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4509",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4510",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4512",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4513",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4514",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4515",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4516",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4517",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NARVNO21",
+    "bank_code": "4520",
+    "name": "Sparebanken Narvik",
+    "short_name": "Sparebanken Narvik"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4530",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4531",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4532",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4533",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4534",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4535",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HELGNO21",
+    "bank_code": "4536",
+    "name": "SpareBank1 Helgeland",
+    "short_name": "SpareBank1 Helgeland"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4540",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NARVNO21",
+    "bank_code": "4545",
+    "name": "Sparebanken Narvik",
+    "short_name": "Sparebanken Narvik"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4550",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4555",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4560",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4570",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4580",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4585",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HASBNO21",
+    "bank_code": "4589",
+    "name": "Sparebank 68 grader Nord",
+    "short_name": "Sparebank 68 grader Nord"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4599",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4602",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HASBNO21",
+    "bank_code": "4605",
+    "name": "Sparebank 68 grader Nord",
+    "short_name": "Sparebank 68 grader Nord"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HASBNO21",
+    "bank_code": "4607",
+    "name": "Sparebank 68 grader Nord",
+    "short_name": "Sparebank 68 grader Nord"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GILDNO21",
+    "bank_code": "4609",
+    "name": "Gildesk\u00e5l Sparebank",
+    "short_name": "Gildesk\u00e5l Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4612",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4618",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4621",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4625",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4628",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4631",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4634",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4638",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NARVNO21",
+    "bank_code": "4642",
+    "name": "Sparebanken Narvik",
+    "short_name": "Sparebanken Narvik"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4648",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "4651",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4657",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HASBNO21",
+    "bank_code": "4658",
+    "name": "Sparebank 68 grader Nord",
+    "short_name": "Sparebank 68 grader Nord"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4662",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4700",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4701",
+    "name": "SpareBank 1 Nord-Norge ",
+    "short_name": "SpareBank 1 Nord-Norge "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4705",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4706",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4708",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4710",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4713",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4714",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4715",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4729",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HASBNO21",
+    "bank_code": "4730",
+    "name": "Sparebank 68 grader Nord",
+    "short_name": "Sparebank 68 grader Nord"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HASBNO21",
+    "bank_code": "4731",
+    "name": "Sparebank 68 grader Nord",
+    "short_name": "Sparebank 68 grader Nord"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4740",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4747",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4750",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4754",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4757",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4760",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4762",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4770",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4776",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4778",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4780",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4782",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4785",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4786",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4787",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4790",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4796",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4799",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4803",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4808",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4811",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4901",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4910",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4911",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4912",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4920",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4930",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4932",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4933",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4935",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4940",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4944",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4950",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4955",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4956",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4957",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4958",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4960",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4961",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4963",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "4965",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5000",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5001",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5002",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5003",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5004",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5005",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5006",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5007",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5008",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5009",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5010",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5011",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5012",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5014",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5015",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5016",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5017",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5018",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5019",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5020",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5021",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5022",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5023",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5024",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5026",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5028",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5029",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5031",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5032",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5033",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5034",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5035",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5036",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5037",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5038",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5039",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5040",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5041",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5042",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5043",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5045",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5046",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5047",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5048",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5049",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5050",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5051",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5052",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5053",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5054",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5055",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5056",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5057",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5059",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5060",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5062",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5063",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5064",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5065",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5066",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5067",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5068",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5070",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5071",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5072",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5073",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5074",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5076",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5077",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5078",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5079",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5080",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5081",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5082",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5083",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5084",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5085",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5086",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5087",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5088",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5090",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5091",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5093",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5094",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5095",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5096",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5097",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5098",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5100",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5101",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5102",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5103",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5104",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5105",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5106",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5107",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5109",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5110",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5112",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5113",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5114",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5115",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5116",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5117",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5118",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5119",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5120",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5121",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5122",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5123",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5124",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5126",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5127",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5128",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5129",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5130",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5131",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5132",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5133",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5134",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5135",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5136",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5137",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5138",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5140",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5141",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5143",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5144",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5145",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5146",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5147",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5148",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5149",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5150",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5151",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5152",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5153",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5154",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5155",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5157",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5158",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5159",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5160",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5161",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5162",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5163",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5164",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5165",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5166",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5167",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5168",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5169",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5170",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5171",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5172",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5174",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5175",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5176",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5177",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5178",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5179",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5181",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5182",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5183",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5184",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5185",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5188",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5189",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5191",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5192",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5193",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5194",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5195",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5196",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5197",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5198",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5199",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5200",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5201",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5202",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5203",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5204",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5205",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5206",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5207",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5208",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5209",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5210",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5211",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5212",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5213",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5214",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5215",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5216",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5217",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5218",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5219",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5220",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5221",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5222",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5224",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5225",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5226",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5227",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5228",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5229",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5230",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5231",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5232",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5233",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5234",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5235",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5236",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5238",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5239",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5241",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5242",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5243",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5244",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5245",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5246",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5249",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5251",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5252",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5253",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5255",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5256",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5257",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5258",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5260",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5261",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5262",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5263",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5264",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5265",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5266",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5267",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5269",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5270",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5272",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5273",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5274",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5275",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5277",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5278",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5279",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5281",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5283",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5286",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5287",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5288",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5289",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5290",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5291",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5293",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5295",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5296",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5297",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5298",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5300",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5301",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5302",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5303",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5305",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5307",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5308",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5309",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5310",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5315",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5320",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5336",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5337",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5338",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5339",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5340",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5343",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5344",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5345",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5346",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5350",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5353",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5354",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5355",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5359",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5360",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5361",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5362",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5363",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5364",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5365",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5367",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5368",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5373",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5375",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5376",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5381",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5385",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5387",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5388",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5389",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5391",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5392",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5394",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5398",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5401",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5404",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5410",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5411",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5412",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5413",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5421",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5451",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5452",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5460",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5470",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5471",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5501",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5503",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5510",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5511",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5512",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5514",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5520",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5521",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5525",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5526",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5535",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5537",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5540",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5541",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5543",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5550",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5551",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5552",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5553",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5554",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5560",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5561",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5562",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5563",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5564",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5565",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5599",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5600",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5601",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5606",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5607",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5611",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5614",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5615",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5621",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5630",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5631",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5632",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5633",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5635",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5636",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5637",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5638",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5639",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5640",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5642",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5646",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5647",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5649",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5650",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5656",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5659",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5661",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5662",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5663",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5664",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5665",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5668",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5669",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5683",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5693",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5700",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5701",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5722",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5726",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5736",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5751",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5754",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5755",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5761",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5762",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5763",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5769",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5770",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5820",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5835",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5838",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5845",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5851",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5856",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5862",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "5960",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6001",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6002",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6003",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6004",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6005",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6006",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6007",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6008",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6009",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6010",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6011",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6012",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6013",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6014",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6015",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6017",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6018",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6019",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6020",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6021",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6022",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6023",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6024",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6025",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6026",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6027",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6028",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6029",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6030",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6031",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6032",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6034",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6035",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6036",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6037",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6038",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6039",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6040",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6041",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6042",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6043",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6044",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6045",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6046",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6048",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6049",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6051",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6052",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6053",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6054",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6055",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6056",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6057",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6058",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6059",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6060",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6061",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6062",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6063",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6065",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6066",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6067",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6068",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6069",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6071",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6072",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6073",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6074",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6075",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6076",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6077",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6079",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6080",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6082",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6083",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6084",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6087",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6089",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6090",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6091",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6092",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6093",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6094",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6096",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6097",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6098",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6100",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6101",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6104",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6105",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6106",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6107",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6108",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6109",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6115",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6116",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6117",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6118",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6120",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6121",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6122",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6123",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6124",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6125",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6129",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6130",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6132",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6133",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6134",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6135",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6136",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6137",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6138",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6139",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6140",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6141",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6142",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6143",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6146",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6154",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6155",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6161",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6163",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6164",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6165",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6167",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6170",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6173",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6174",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6177",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6178",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6179",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6182",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6184",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6185",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6188",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6189",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6191",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6197",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6200",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6201",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6202",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6203",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6204",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6205",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6206",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6207",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6208",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6210",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6211",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6213",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6215",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6217",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6219",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6220",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6221",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6222",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6223",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6224",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6225",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6227",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6228",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6229",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6230",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6232",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6233",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6234",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6235",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6236",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6237",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6238",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6240",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6241",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6242",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6244",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6245",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6249",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6250",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6251",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6252",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6255",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6261",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6262",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6263",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6264",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6265",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6266",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6272",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6273",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6276",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6280",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6295",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6296",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6298",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6299",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6302",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6303",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6304",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6311",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6312",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6313",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6315",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6316",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6317",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6318",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6319",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6320",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6321",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6322",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6323",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6324",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6325",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6326",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6327",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6330",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6335",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6337",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6340",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6345",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6346",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6350",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6351",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6352",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6353",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6360",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6365",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6366",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6367",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6370",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6401",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6402",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6404",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6405",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6406",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6407",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6408",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6409",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6410",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6411",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6412",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6413",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6415",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6418",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6420",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6421",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6428",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6433",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6434",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6437",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6443",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6444",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6446",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6449",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6452",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6468",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6473",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6476",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6501",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6502",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6503",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6504",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6509",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6510",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6511",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6512",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6513",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6515",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6516",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6517",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6518",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6519",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6524",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6525",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6526",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6527",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6529",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6537",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6539",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6540",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6541",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6542",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6543",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6545",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6546",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6547",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6550",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6554",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6555",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6556",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6557",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6558",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6559",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6560",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6561",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6562",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6563",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6566",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6567",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6568",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6569",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6570",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6575",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6580",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6584",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6592",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6593",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6594",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6595",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6600",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6602",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6610",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6615",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6616",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6621",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6623",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6630",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6631",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6632",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6634",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6635",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6636",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6649",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6653",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6654",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6656",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6660",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6661",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6662",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6666",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6670",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6671",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6672",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6676",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6677",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6678",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6681",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6684",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6690",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6691",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6692",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6701",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6702",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6707",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6708",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6709",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6713",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6714",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6717",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6721",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6722",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6728",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6729",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6730",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6737",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6738",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6743",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6749",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6750",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6769",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6779",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6781",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6784",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6788",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6790",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6793",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6797",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6798",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6799",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6803",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6805",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6806",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6810",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6811",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6813",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6816",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6819",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6822",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6823",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6825",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6828",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6831",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6832",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6836",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6837",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6841",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6845",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6846",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6849",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6851",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6852",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6877",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6882",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6892",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6911",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6918",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6923",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6924",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6954",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NDEANOKK",
+    "bank_code": "6997",
+    "name": "Nordea Bank Abp, Filial i Norge",
+    "short_name": "Nordea Bank Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7001",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7002",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7003",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7004",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7006",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7007",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7008",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7009",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7010",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7011",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7012",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7013",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7014",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7016",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7017",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7018",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7020",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7021",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7023",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7025",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7026",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7028",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7029",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7030",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7032",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7033",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7034",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7035",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7038",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7039",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7041",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7042",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7044",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7045",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7047",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7050",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7052",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7054",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7056",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7057",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7058",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7060",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7061",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7062",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7064",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7066",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7068",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7069",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7072",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7074",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7076",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7077",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7082",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7085",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7087",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7089",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7090",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7094",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7097",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7100",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7101",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7102",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7104",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7105",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7106",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7107",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7108",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7109",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7111",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7112",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7113",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7114",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7115",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7116",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7118",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7119",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7121",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7122",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7124",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7125",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7126",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7127",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7128",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7129",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7130",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7131",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7132",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7133",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7135",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7136",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7137",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7138",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7139",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7141",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7142",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7143",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7144",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7145",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7146",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7147",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7149",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7150",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7152",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7153",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7154",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7156",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7158",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7159",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7160",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7161",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7162",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7163",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7164",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7166",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7167",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7168",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7169",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7170",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7171",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7172",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7174",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7175",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7176",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7177",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7178",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7181",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7183",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7184",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7186",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7188",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7189",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7190",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7191",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7192",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7193",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7194",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7195",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7198",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7202",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7203",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7204",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7205",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7206",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7207",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7208",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7209",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7210",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7211",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7212",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7213",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7214",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7216",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7220",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7221",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7224",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7226",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7227",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7228",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7230",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7231",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7233",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7234",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7235",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7236",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7237",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7238",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7239",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7240",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7243",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7245",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7251",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7253",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7258",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7259",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7260",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7261",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7262",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7264",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7265",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7273",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7282",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7285",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7288",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7289",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7290",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7291",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7292",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7293",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7295",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7296",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7297",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7298",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7299",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7301",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7304",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7306",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7307",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7309",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7310",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7312",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7314",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7315",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7316",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7319",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7322",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7323",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7325",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7326",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7328",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7331",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7332",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7333",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7334",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7335",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7336",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7337",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7362",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7364",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7367",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7368",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7370",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7400",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7401",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7403",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7404",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7406",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7407",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7413",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7416",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7421",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7426",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7431",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7435",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7441",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7450",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7451",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7457",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7460",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7462",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7472",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7474",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7475",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7476",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7477",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7478",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7479",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7492",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7493",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7495",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7501",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7502",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7508",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7509",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7513",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7514",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7516",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7517",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7518",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7520",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7535",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7550",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7553",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7554",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7555",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7560",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7561",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7573",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7575",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7576",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7581",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7584",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7587",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7588",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7592",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7593",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7594",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7595",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7596",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7597",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7600",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7603",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7606",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7609",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7613",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7614",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7615",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7623",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7640",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7644",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7656",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7660",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7670",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7684",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7686",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7690",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7691",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7692",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7693",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7694",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7695",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7696",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7698",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7699",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7701",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7703",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7704",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7711",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7712",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7725",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7726",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7727",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7728",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7729",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7731",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7732",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7734",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7735",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7736",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7737",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7745",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7746",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7748",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7766",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7780",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7788",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7801",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7804",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7806",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7807",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7808",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7809",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7810",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7811",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7813",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7818",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7821",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7823",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7824",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7830",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7832",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7833",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7834",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7839",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7841",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7842",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7843",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7844",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7846",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7848",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7849",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7850",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7851",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7853",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7854",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7857",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7858",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7859",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7860",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7861",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7863",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7868",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7874",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7877",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7878",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7881",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7882",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7883",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7884",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7885",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7886",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7887",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7888",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7889",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7894",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7896",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7898",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7899",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7900",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7902",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7903",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7904",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7905",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7906",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7907",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7908",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7910",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7911",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7913",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7914",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7917",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7919",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7922",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7923",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7924",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7925",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7926",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7927",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7929",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7931",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7934",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7935",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7937",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7938",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7942",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7946",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7949",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7961",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7962",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7966",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7972",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7973",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7974",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7976",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7977",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7978",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7979",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7981",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7989",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7990",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7993",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7995",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7996",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7997",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7998",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "7999",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8101",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8102",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8103",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8109",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8110",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8111",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8120",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8122",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8124",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8126",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8128",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "8133",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8143",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8150",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8156",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8160",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8170",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8194",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8200",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8205",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8210",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8215",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPSONO22",
+    "bank_code": "8220",
+    "name": "Sparebanken S\u00f8r",
+    "short_name": "Sparebanken S\u00f8r"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8225",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8230",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8240",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8245",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8250",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8255",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8272",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8276",
+    "name": "DNB Bank ASA ",
+    "short_name": "DNB Bank ASA "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8280",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8281",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "CITINOKX",
+    "bank_code": "8301",
+    "name": "Citibank Europe PLC",
+    "short_name": "Citibank Europe PLC"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "CITINOKX",
+    "bank_code": "8303",
+    "name": "Citibank International PLC ",
+    "short_name": "Citibank International PLC "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KLPKNO21",
+    "bank_code": "8317",
+    "name": "KLP Banken AS",
+    "short_name": "KLP Banken AS"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8380",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8382",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8383",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8384",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8385",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8386",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "8394",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "8396",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "8397",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "8398",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8420",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8426",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8450",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8471",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8472",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8475",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8478",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8480",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8483",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8507",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8508",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8510",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8511",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8513",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8514",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8515",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8516",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8530",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8535",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8540",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8545",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8580",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8601",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8603",
+    "name": "Danske Bank ",
+    "short_name": "Danske Bank "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8604",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8605",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8606",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8630",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8631",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8635",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8636",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8640",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8642",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8643",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8644",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8647",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8650",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8652",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8653",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8654",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8670",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8671",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8673",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8674",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "8676",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9001",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9002",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9003",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9004",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9005",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9006",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9007",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9008",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "9011",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9012",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPAVNOBB",
+    "bank_code": "9013",
+    "name": "Sparebanken Vest",
+    "short_name": "Sparebanken Vest"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "9015",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "RYGSNO21",
+    "bank_code": "9016",
+    "name": "Sparebank1 \u00d8stfold Akershus",
+    "short_name": "Sparebank1 \u00d8stfold Akershus"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VEFONO21",
+    "bank_code": "9017",
+    "name": "SpareBank 1 S\u00f8r\u00f8st-Norge",
+    "short_name": "SpareBank 1 S\u00f8r\u00f8st-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SNOWNO22",
+    "bank_code": "9019",
+    "name": "SpareBank 1 Nord-Norge",
+    "short_name": "SpareBank 1 Nord-Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BNPANOKK",
+    "bank_code": "9021",
+    "name": "BNP Paribas S.A. Norway Branch ",
+    "short_name": "BNP Paribas S.A. Norway Branch "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9041",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9042",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9043",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9044",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9046",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9047",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9048",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9049",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9050",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9051",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9052",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9053",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9054",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9055",
+    "name": "Handelsbanken",
+    "short_name": "Handelsbanken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9056",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9061",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9063",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9064",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9065",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9066",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9069",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "STFBNOKK",
+    "bank_code": "9100",
+    "name": "Storebrand Bank ASA",
+    "short_name": "Storebrand Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9149",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "IEVENO21",
+    "bank_code": "9175",
+    "name": "N\u00e6ringsbanken ASA",
+    "short_name": "N\u00e6ringsbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOMNO21",
+    "bank_code": "9180",
+    "name": "Santander Consumer Bank AS",
+    "short_name": "Santander Consumer Bank AS"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOMNO21",
+    "bank_code": "9181",
+    "name": "Santander Consumer Bank AS ",
+    "short_name": "Santander Consumer Bank AS "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOMNO21",
+    "bank_code": "9182",
+    "name": "Santander Consumer Bank AS ",
+    "short_name": "Santander Consumer Bank AS "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOMNO21",
+    "bank_code": "9183",
+    "name": "Santander Consumer Bank AS ",
+    "short_name": "Santander Consumer Bank AS "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOMNO21",
+    "bank_code": "9184",
+    "name": "Santander Consumer Bank AS ",
+    "short_name": "Santander Consumer Bank AS "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOMNO21",
+    "bank_code": "9187",
+    "name": "Santander Consumer Bank AS ",
+    "short_name": "Santander Consumer Bank AS "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "9201",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "9202",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "9203",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "9204",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SAOENO22",
+    "bank_code": "9205",
+    "name": "Sparebanken \u00d8st",
+    "short_name": "Sparebanken \u00d8st"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HAALNO21",
+    "bank_code": "9211",
+    "name": "Sparebank 1 Hallingdal Valdres",
+    "short_name": "Sparebank 1 Hallingdal Valdres"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KBNONO22",
+    "bank_code": "9230",
+    "name": "BN Bank ASA",
+    "short_name": "BN Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "KBNONO22",
+    "bank_code": "9235",
+    "name": "BN Bank ASA",
+    "short_name": "BN Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NRCANOK2",
+    "bank_code": "9246",
+    "name": "Nordic Corporate Bank ASA",
+    "short_name": "Nordic Corporate Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORWNOK1",
+    "bank_code": "9355",
+    "name": "Bank Norwegian, Filial av Nordax Bank AB (PUBL)",
+    "short_name": "Bank Norwegian, Filial av Nordax Bank AB (PUBL)"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORWNOK1",
+    "bank_code": "9356",
+    "name": "Bank Norwegian, Filial av Nordax Bank AB (PUBL)",
+    "short_name": "Bank Norwegian, Filial av Nordax Bank AB (PUBL)"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORWNOK1",
+    "bank_code": "9357",
+    "name": "Bank Norwegian, Filial av Nordax Bank AB (PUBL)",
+    "short_name": "Bank Norwegian, Filial av Nordax Bank AB (PUBL)"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "NORWNOK1",
+    "bank_code": "9358",
+    "name": "Bank Norwegian, Filial av Nordax Bank AB (PUBL)",
+    "short_name": "Bank Norwegian, Filial av Nordax Bank AB (PUBL)"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LANDNOK1",
+    "bank_code": "9364",
+    "name": "Landkreditt Bank AS",
+    "short_name": "Landkreditt Bank AS"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LANDNOK1",
+    "bank_code": "9365",
+    "name": "Landkreditt Bank AS",
+    "short_name": "Landkreditt Bank AS"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9371",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9372",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9373",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9374",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "MYASNOK1",
+    "bank_code": "9376",
+    "name": "MyBank",
+    "short_name": "MyBank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "PTAANOK1",
+    "bank_code": "9380",
+    "name": "Pareto Bank ASA",
+    "short_name": "Pareto Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9480",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9481",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9483",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9484",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9485",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9486",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9487",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9488",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9489",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9490",
+    "name": "Handelsbanken",
+    "short_name": "Handelsbanken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9491",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9492",
+    "name": "Handelsbanken",
+    "short_name": "Handelsbanken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9493",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9494",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9495",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9497",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9498",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9499",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9521",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9522",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9523",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9524",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9525",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9526",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9528",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9530",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9531",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9533",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9535",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9536",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9537",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9538",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VVELNO21",
+    "bank_code": "9581",
+    "name": "Voss Veksel-og Landmandsbank",
+    "short_name": "Voss Veksel-og Landmandsbank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ESSENO22",
+    "bank_code": "9590",
+    "name": "Skandinaviska Enskilda Banken AB (publ) ",
+    "short_name": "Skandinaviska Enskilda Banken AB (publ) "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SASKNO22",
+    "bank_code": "9600",
+    "name": "Sandnes Sparebank",
+    "short_name": "Sandnes Sparebank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "LUNADK2C",
+    "bank_code": "9602",
+    "name": "Lunar Bank A/S",
+    "short_name": "Lunar Bank A/S"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "BTWONOK1",
+    "bank_code": "9615",
+    "name": "Bank2 ASA",
+    "short_name": "Bank2 ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9650",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9651",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9652",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9653",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9654",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9655",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9656",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9657",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPTRNO22",
+    "bank_code": "9662",
+    "name": "SpareBank 1 SMN",
+    "short_name": "SpareBank 1 SMN"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "PRBONO22",
+    "bank_code": "9666",
+    "name": "Boligbanken ASA",
+    "short_name": "Boligbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "STFBNOKK",
+    "bank_code": "9680",
+    "name": "Storebrand Bank ASA",
+    "short_name": "Storebrand Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9685",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9686",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9687",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "HANDNOKK",
+    "bank_code": "9688",
+    "name": "Handelsbanken ",
+    "short_name": "Handelsbanken "
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9701",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9702",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9703",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9704",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9705",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9706",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9707",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DNBANOKK",
+    "bank_code": "9709",
+    "name": "DNB Bank ASA",
+    "short_name": "DNB Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9710",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9713",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9722",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9723",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9726",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9727",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9729",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9731",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9735",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9741",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9745",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9747",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ESSENOKX",
+    "bank_code": "9750",
+    "name": "Skandinaviska Enskilda Banken",
+    "short_name": "Skandinaviska Enskilda Banken"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ESSENOKX",
+    "bank_code": "9751",
+    "name": "SEB AB, Oslofilialen",
+    "short_name": "SEB AB, Oslofilialen"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "ESSENOKX",
+    "bank_code": "9752",
+    "name": "SEB AB, Oslofilialen",
+    "short_name": "SEB AB, Oslofilialen"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "DABANO22",
+    "bank_code": "9760",
+    "name": "Danske Bank",
+    "short_name": "Danske Bank"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "GJASNO21",
+    "bank_code": "9775",
+    "name": "Nordea Bank  Abp, Filial i Norge",
+    "short_name": "Nordea Bank  Abp, Filial i Norge"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VERDNOK1",
+    "bank_code": "9791",
+    "name": "Lea Bank ASA",
+    "short_name": "Lea Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "VERDNOK1",
+    "bank_code": "9792",
+    "name": "Lea Bank ASA",
+    "short_name": "Lea Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9801",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9802",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9803",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9804",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9805",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9807",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9808",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9809",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SBAKNOBB",
+    "bank_code": "9810",
+    "name": "Sbanken ASA",
+    "short_name": "Sbanken ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "TEKONOK1",
+    "bank_code": "9812",
+    "name": "Eika Kredittbank AS",
+    "short_name": "Eika Kredittbank AS"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "OBOSNOK1",
+    "bank_code": "9820",
+    "name": "OBOSBanken AS",
+    "short_name": "OBOSBanken AS"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SPRONO22",
+    "bank_code": "9841",
+    "name": "SpareBank 1 SR-Bank ASA",
+    "short_name": "SpareBank 1 SR-Bank ASA"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9850",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9851",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9852",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9853",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9855",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9856",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9857",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9858",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9859",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9860",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9861",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9862",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9863",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9864",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9865",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9866",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9867",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9880",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9890",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "SHEDNO22",
+    "bank_code": "9895",
+    "name": "SpareBank 1 \u00d8stlandet",
+    "short_name": "SpareBank 1 \u00d8stlandet"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "YABANOK1",
+    "bank_code": "9900",
+    "name": "Resurs Bank AB NUF",
+    "short_name": "Resurs Bank AB NUF"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "YABANOK1",
+    "bank_code": "9902",
+    "name": "Resurs Bank AB NUF",
+    "short_name": "Resurs Bank AB NUF"
+  },
+  {
+    "country_code": "NO",
+    "primary": true,
+    "bic": "YABANOK1",
+    "bank_code": "9903",
+    "name": "Resurs Bank AB NUF",
+    "short_name": "Resurs Bank AB NUF"
+  }
+]

--- a/scripts/get_bank_registry_no.py
+++ b/scripts/get_bank_registry_no.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+import json
+
+import pandas
+
+
+URL = "https://www.bits.no/document/iban/"
+
+
+def process():
+    datas = pandas.read_excel(URL, sheet_name=0, dtype=str, header=None)
+    datas.fillna("", inplace=True)
+
+    return [
+        {
+            "country_code": "NO",
+            "primary": True,
+            "bic": str(bic).upper().strip(),
+            "bank_code": bank_code,
+            "name": name,
+            "short_name": name,
+        }
+        for bank_code, bic, name in list(datas.itertuples(index=False))[1:]
+        if bank_code != ""
+    ]
+
+
+if __name__ == "__main__":
+    with open("schwifty/bank_registry/generated_no.json", "w") as fp:
+        json.dump(process(), fp, indent=2)

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -4,7 +4,7 @@ set -o errexit
 main() {
   local -r root=$(dirname "${BASH_SOURCE[0]}")
 
-  for country in "at" "be" "cz" "de" "es" "fi" "hr" "hu" "lv" "lt" "nl" "pl" "ro" "si" "sk" "ua"; do
+  for country in "at" "be" "cz" "de" "es" "fi" "hr" "hu" "lv" "lt" "nl" "pl" "ro" "si" "sk" "ua" "no"; do
     echo "---> Updating bank registry for: ${country}"
     python "${root}/get_bank_registry_${country}.py"
   done


### PR DESCRIPTION
This PR adds a script to generate a bank registry for Norwegian banks. It uses the official source, available at https://www.bits.no/document/iban/

Relevant links: https://bits.no/en/iban