### PR TITLE
chore(python): add Python 3.12 in test matrix

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -75,13 +75,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
       - name: Install dependencies
         run: pip install tox
       - name: Test

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifier =
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
 
 [options]
 packages = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = True
-envlist = py{37,38,39,310,311},lint,lint-docs,fmt,mypy
+envlist = py{37,38,39,310,311,312},lint,lint-docs,fmt,mypy
 
 [testenv]
 deps =


### PR DESCRIPTION
This PR adds Python 3.12 in test matrix.

Note: I had to allow pre releases since Python 3.12 is still in beta and will land soon in release candidate.