### PR TITLE
Allow digits as a bank code in BIC according to ISO 9362:2022(E)

### DIFF
--- a/schwifty/bic.py
+++ b/schwifty/bic.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from pydantic import GetCoreSchemaHandler
     from pydantic_core import CoreSchema
 
-_bic_re = re.compile(r"[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}(?:[A-Z0-9]{3})?")
+_bic_re = re.compile(r"[A-Z0-9]{4}[A-Z]{2}[A-Z0-9]{2}(?:[A-Z0-9]{3})?")
 
 
 class BIC(common.Base):

--- a/tests/test_bic.py
+++ b/tests/test_bic.py
@@ -78,6 +78,7 @@ def test_unknown_bic_properties() -> None:
         ("GENODEM1GLS", "passive"),
         ("GENODEM2GLS", "reverse billing"),
         ("GENODEMMGLS", "default"),
+        ("1234DEWWXXX", "default"),
     ],
 )
 def test_bic_type(code: str, type: str) -> None:  # noqa: A002
@@ -90,7 +91,6 @@ def test_bic_type(code: str, type: str) -> None:  # noqa: A002
     [
         ("AAAA", exceptions.InvalidLength),
         ("AAAADEM1GLSX", exceptions.InvalidLength),
-        ("12ABDEM1GLS", exceptions.InvalidStructure),
         ("GENOD1M1GLS", exceptions.InvalidStructure),
         ("GENOXXM1GLS", exceptions.InvalidCountryCode),
     ],


### PR DESCRIPTION
A new standard [ISO 9362:2022(E)](https://www.iso.org/standard/84108.html) allows digits as a bank code in BIC.

I came across this when I was making quarter updates in SEPA documents in the Bank of Lithuania.