### PR TITLE
Boursorama is now called Boursobank

### DIFF
--- a/schwifty/bank_registry/manual_fr.json
+++ b/schwifty/bank_registry/manual_fr.json
@@ -2123,8 +2123,8 @@
         "country_code": "FR",
         "bic": "BOUSFRPPXXX",
         "bank_code": "40618",
-        "name": "BOURSORAMA",
-        "short_name": "BOURSORAMA",
+        "name": "BOURSOBANK",
+        "short_name": "BOURSOBANK",
         "primary": true
     },
     {


### PR DESCRIPTION
Since October 2nd, Boursorama is now called Boursobank

source : https://www.boursobank.com/aide-en-ligne/mon-espace-client/boursorama-banque-devient-boursobank/question/comment-va-se-derouler-le-passage-de-boursorama-banque-vers-boursobank-91152739