### PR TITLE
Add OKALI to the list of French banks.

### DIFF
--- a/schwifty/bank_registry/manual_fr.json
+++ b/schwifty/bank_registry/manual_fr.json
@@ -2398,5 +2398,13 @@
         "name": "SWAN",
         "short_name": "SWAN",
         "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SFPEFRP2",
+        "bank_code": "17448",
+        "name": "OKALI",
+        "short_name": "OKALI",
+        "primary": true
     }
 ]


### PR DESCRIPTION
I tried to use the registry to findout the BIC from the couple `("FR", "17448")` but couldn't find it in the registry.

![image](https://github.com/mdomke/schwifty/assets/229453/b7bbfabd-f94a-42f7-a43f-f36227aadaf6)
