### PR TITLE
Add missing SHINE bank

### DIFF
--- a/schwifty/bank_registry/manual_fr.json
+++ b/schwifty/bank_registry/manual_fr.json
@@ -2406,5 +2406,13 @@
         "name": "OKALI",
         "short_name": "OKALI",
         "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "SNNNFR22",
+        "bank_code": "17418",
+        "name": "SHINE",
+        "short_name": "SHINE",
+        "primary": true
     }
 ]


### PR DESCRIPTION
I tried to use the registry to find out the BIC from the couple ("FR", "17418") but couldn't find it in the registry.

![image](https://github.com/mdomke/schwifty/assets/229453/20f92941-b452-4ca3-a47e-c2f9a4215619)
