### PR TITLE
Add bnext to manual ES registry

### DIFF
--- a/schwifty/bank_registry/manual_es.json
+++ b/schwifty/bank_registry/manual_es.json
@@ -30,5 +30,13 @@
     "bic": "UCJAES2MXXX",
     "name": "UNICAJA BANCO, S.A.",
     "short_name": "UNICAJA"
+  },
+  {
+    "country_code": "ES",
+    "primary": true,
+    "bank_code": "6717",
+    "bic": "BNXTESM2",
+    "name": "BNEXT ELECTRONIC ISSUER, EDE, S.L.",
+    "short_name": "Bnext"
   }
 ]


### PR DESCRIPTION
Bnext is a spanish neobank that offers bank accounts: https://bnext.es/cuenta

It is registerd in banco de españa (https://www.bde.es/webbe/en/estadisticas/otras-clasificaciones/clasificacion-entidades/listas-instituciones-financieras/listas-instituciones-financieras-monetarias-pais/lista-mfi-es.html)

