### PR TITLE
added GB banks to the registry

### DIFF
--- a/schwifty/bank_registry/manual_gb.json
+++ b/schwifty/bank_registry/manual_gb.json
@@ -186,9 +186,9 @@
   {
     "country_code": "GB",
     "primary": true,
-    "bic": "HALIFAX (A TRADING NAME OF BANK OF SCOTLAND PLC)",
+    "bic": "HLFXGB22XXX",
     "bank_code": "HLFX",
-    "name": "HALIFAX (A TRADING NAME OF BANK OF SCOTLAND PLC)",
+    "name": "BANK OF SCOTLAND PLC",
     "short_name": "HALIFAX"
   },
   {
@@ -306,8 +306,8 @@
   {
     "country_code": "GB",
     "primary": true,
-    "bic": "REVO",
-    "bank_code": "REVOGB21",
+    "bic": "REVOGB21XXX",
+    "bank_code": "REVO",
     "name": "REVOLUT LTD",
     "short_name": "REVOLUT LTD"
   },
@@ -315,7 +315,7 @@
     "country_code": "GB",
     "primary": true,
     "bic": "REVOGB21XXX",
-    "bank_code": "REVO",
+    "bank_code": "NWBK",
     "name": "REVOLUT LTD",
     "short_name": "REVOLUT LTD"
   },


### PR DESCRIPTION
Added new banks in banks registry from issue #138

Banks that were **added**:
MONZGB2L
PAYRGB2L
DZNNGB22
CPBKGB22
YORKGB22
TCCLGB3L
TSBSGB2A

I've noticed that some banks from the existing registry are now inactive.. so I will note those:
Inactive swift codes:
PRTCGB21
HLFXGB21N85
TCCLGB31XXX
PAYRGB21
PAEDGB21XXX
REVOGB21XXX
CLJUGB21XXX
PRTCGB21XXX
REVOGB21
CPBKGB21CAR

Deleted from network:
SVBKGB2L

I haven't removed them from the registry, but I am noting this for future reference.

Thank you :)