### PR TITLE
Fix Python 3.8 compatibility

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -63,4 +63,4 @@ jobs:
       - name: Smoke test installation
         run: pip install .
       - name: Test
-        run: hatch test --cover
+        run: hatch test --cover --python ${{ matrix.python-version }}

--- a/schwifty/registry.py
+++ b/schwifty/registry.py
@@ -72,7 +72,7 @@ def parse_v2(data: dict[str, Any]) -> list[dict[str, Any]]:
     def expand(entry: dict[str, Any], src: str, dst: str) -> list[dict[str, Any]]:
         values = entry.pop(src)
         entry.setdefault("primary", False)
-        return [entry | {dst: value} for value in values]
+        return [{**entry, dst: value} for value in values]
 
     return list(
         itertools.chain.from_iterable(


### PR DESCRIPTION
Also tweak CI/CD so that the tests run on each Python version (formally hatch ignored the configured Python version in favour of a global 3.12 environment, hiding this issue).

Fixes #220