### PR TITLE
Add modulr to ES registry

### DIFF
--- a/schwifty/bank_registry/manual_es.json
+++ b/schwifty/bank_registry/manual_es.json
@@ -44,7 +44,7 @@
     "primary": true,
     "bank_code": "6723",
     "bic": "MODRESB2",
-    "name": "MODULR FINANCE B.V.,",
+    "name": "MODULR FINANCE B.V., SPAIN BRANCH",
     "short_name": "MODULR FINANCE"
   }
 ]

--- a/schwifty/bank_registry/manual_es.json
+++ b/schwifty/bank_registry/manual_es.json
@@ -38,5 +38,13 @@
     "bic": "BNXTESM2",
     "name": "BNEXT ELECTRONIC ISSUER, EDE, S.L.",
     "short_name": "Bnext"
+  },
+  {
+    "country_code": "ES",
+    "primary": true,
+    "bank_code": "6723",
+    "bic": "MODRESB2",
+    "name": "MODULR FINANCE B.V.,",
+    "short_name": "MODULR FINANCE"
   }
 ]


### PR DESCRIPTION
Modular is a bank which is already in other countries' registry, but the spanish branch was missing

It is registered in banco de españa (https://www.bde.es/webbe/en/estadisticas/otras-clasificaciones/clasificacion-entidades/listas-instituciones-financieras/listas-instituciones-financieras-monetarias-pais/lista-mfi-es.html)