### PR TITLE
Remove support for deprecated Python version 3.8

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changelog
 
 Versions follow `CalVer <http://www.calver.org/>`_ with the scheme ``YY.0M.Micro``.
 
+`2024.11.0`_ - 2024/11/11
+-------------------------
+Changed
+~~~~~~~
+* Removed support for deprecated Python version 3.8
+
 `2024.09.0`_ - 2024/09/31
 -------------------------
 Fixed
@@ -685,6 +691,7 @@ Added
 * Added :attr:`.BIC.country` and :attr:`.IBAN.country`.
 
 
+.. _2024.11.0: https://github.com/mdomke/schwifty/compare/2024.09.0...2024.11.0
 .. _2024.09.0: https://github.com/mdomke/schwifty/compare/2024.08.1...2024.09.0
 .. _2024.08.1: https://github.com/mdomke/schwifty/compare/2024.08.0...2024.08.1
 .. _2024.08.0: https://github.com/mdomke/schwifty/compare/2024.06.1...2024.08.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,13 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Martin Domke", email = "mail@martindomke.net" },
 ]

--- a/schwifty/bban.py
+++ b/schwifty/bban.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from random import Random
 from typing import Any
 from typing import cast
-from typing import Dict
 
 from rstr import Rstr
 
@@ -183,7 +182,7 @@ class BBAN(common.Base):
         if random is None:
             random = Random()  # noqa: S311
 
-        banks_by_country = cast(Dict[str, Any], registry.get("country"))
+        banks_by_country = cast(dict[str, Any], registry.get("country"))
         if not country_code:
             country_code = random.choice(list(banks_by_country.keys()))
 

--- a/schwifty/registry.py
+++ b/schwifty/registry.py
@@ -6,8 +6,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import List
 from typing import Union
 
 
@@ -18,7 +16,7 @@ except ImportError:
 
 
 Key = Union[str, tuple]
-Value = Union[Dict[Key, Any], List[Dict[Key, Any]]]
+Value = Union[dict[Key, Any], list[dict[Key, Any]]]
 
 _registry: dict[Key, Value] = {}
 


### PR DESCRIPTION
Python 3.8 is officially not supported anymore since October 2024. Removing support for this version, allows us to use more modern syntax features and keep the code up to speed with the development of the language.