### PR TITLE
add the UK branch of Banking circle to the registry

### DIFF
--- a/schwifty/bank_registry/manual_gb.json
+++ b/schwifty/bank_registry/manual_gb.json
@@ -326,5 +326,13 @@
     "name": "TRANSFERWISE LIMITED",
     "short_name": "TRANSFERWISE LIMITED",
     "primary": true
+  },
+  {
+    "country_code": "GB",
+    "bic": "SAPYGB2L",
+    "bank_code": "SAPY",
+    "name": "BANKING CIRCLE S.A. UK Branch",
+    "short_name": "BANKING CIRCLE",
+    "primary": true
   }
 ]


### PR DESCRIPTION
Adds the UK branch details for banking circle. 

https://www.bankingcircle.com/regulatory-information/

I'm not sure about the sorting of the json, so I stuck it to the end.