### PR TITLE
Add a few french banks

### DIFF
--- a/schwifty/bank_registry/manual_fr.json
+++ b/schwifty/bank_registry/manual_fr.json
@@ -2550,5 +2550,77 @@
         "name": "SOGEXIA S.A",
         "short_name": "SOGEXIA S.A",
         "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPP",
+        "bank_code": "11978",
+        "name": "CREDIT INDUSTRIEL ET COMMERCIAL-CIC",
+        "short_name": "CM - CIC BANQUES",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPP",
+        "bank_code": "13580",
+        "name": "FACTOFRANCE",
+        "short_name": "FACTOFRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPP",
+        "bank_code": "13888",
+        "name": "HSBC FACTORING FRANCE",
+        "short_name": "HSBC FACTORING FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "CMCIFRPP",
+        "bank_code": "16478",
+        "name": "HSBC FACTORING FRANCE",
+        "short_name": "HSBC FACTORING FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "AGRIFRP1EFG",
+        "bank_code": "16850",
+        "name": "CREDIT AGRICOLE SA (LEASING AND FACTORING)",
+        "short_name": "CREDIT AGRICOLE SA (LEASING AND FACTORING)",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "NTSBFRM1",
+        "bank_code": "20433",
+        "name": "N26 BANK GMBH, SUCCURSALE FRANCE",
+        "short_name": "N26 FRANCE",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "MPAYFRP1",
+        "bank_code": "21933",
+        "name": "MANGOPAY SA FRANCE",
+        "short_name": "MANGOPAY",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "BUNQFRP2",
+        "bank_code": "27633",
+        "name": "BUNQ B.V.",
+        "short_name": "BUNQ B.V.",
+        "primary": true
+    },
+    {
+        "country_code": "FR",
+        "bic": "FNOMFRP2",
+        "bank_code": "30833",
+        "name": "FINOM PAYMENTS B.V.",
+        "short_name": "FINOM PAYMENTS B.V.",
+        "primary": true
     }
 ]


### PR DESCRIPTION
Add a few french banks we discovered at Defacto (https://getdefacto.com).

We discovered the bank codes from IBAN shared by our users.

The source for bank names is https://bank-codes.fr/swift-code/france/facffrpp/ which is maintained by Wise.