### PR TITLE
Add short project description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "schwifty"
 dynamic = ["version"]
+description = "IBAN parsing and validation"
 readme = "README.rst"
 license = "MIT"
 classifiers = [


### PR DESCRIPTION
Should be picked up by PyPI and others.

Currently, schwifty appears in PyPI search results with a description of "None".