### PR TITLE
Fix `get_bank_registry_it` and update generated IT bank registry

### DIFF
--- a/schwifty/bank_registry/generated_it.json
+++ b/schwifty/bank_registry/generated_it.json
@@ -3,17 +3,9 @@
     "country_code": "IT",
     "primary": true,
     "bic": "ICRAITRR",
-    "bank_code": "08517",
-    "name": "BANCA DI CREDITO COOPERATIVO DI CRETA - CREDITO COOPERATIVO PIACENTINO - SOCIETA' COOPERATIVA",
-    "short_name": "BANCA DI CREDITO COOPERATIVO DI CRETA - CREDITO COOPERATIVO PIACENTINO - SOCIETA' COOPERATIVA"
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "ICRAITRRE50",
     "bank_code": "08509",
-    "name": "\"\"BANCA CENTRO EMILIA - CREDITO COOPERATIVO\" SOCIETA' COOPERATIVA\"",
-    "short_name": "\"\"BANCA CENTRO EMILIA - CREDITO COOPERATIVO\" SOCIETA' COOPERATIVA\""
+    "name": "'BANCA CENTRO EMILIA - CREDITO COOPERATIVO' SOCIETA' COOPERATIVA",
+    "short_name": "'BANCA CENTRO EMILIA - CREDITO COOPERATIVO' SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -27,49 +19,33 @@
     "country_code": "IT",
     "primary": true,
     "bic": "BPMOIT22",
-    "bank_code": "05256",
-    "name": "BANCA POPOLARE DI CROTONE - SOCIETA' PER AZIONI",
-    "short_name": "BANCA POPOLARE DI CROTONE - SOCIETA' PER AZIONI"
+    "bank_code": "05387",
+    "name": "BANCA POPOLARE DELL'EMILIA ROMAGNA SOC. COOP.",
+    "short_name": "BANCA POPOLARE DELL'EMILIA ROMAGNA SOC. COOP."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "07073",
+    "name": "BANCA ROMAGNA COOPERATIVA CREDITO COOP. ROMAGNA CENTRO E MACERONE S.C.",
+    "short_name": "BANCA ROMAGNA COOPERATIVA CREDITO COOP. ROMAGNA CENTRO E MACERONE S.C."
   },
   {
     "country_code": "IT",
     "primary": true,
     "bic": "BLOPIT22",
-    "bank_code": "10633",
-    "name": "CENTROBANCA - BANCA DI CREDITO FINANZIARIO E MOBILIARE S.P.A.",
-    "short_name": "CENTROBANCA S.P.A."
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "ICRAITR1",
-    "bank_code": "08851",
-    "name": "TERRE ETRUSCHE DI VALDICHIANA E DI MAREMMA - CREDITO COOPERATIVO- S.C.",
-    "short_name": "TERRE ETRUSCHE DI VALDICHIANA E DI MAREMMA - CREDITO COOPERATIVO- S.C."
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "CCRTIT2TBDB",
-    "bank_code": "08883",
-    "name": "BANCA DI BOLOGNA CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
-    "short_name": "BANCA DI BOLOGNA CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "UNCRITMM",
-    "bank_code": "02008",
-    "name": "UNICREDIT BANCA S.P.A.",
-    "short_name": "UNICREDIT BANCA S.P.A."
+    "bank_code": "03331",
+    "name": "CENTRO LEASING BANCA SOCIETA' PER AZIONI",
+    "short_name": "CENTRO LEASING BANCA S.P.A."
   },
   {
     "country_code": "IT",
     "primary": true,
     "bic": "CCRTIT2T",
-    "bank_code": "10638",
-    "name": "MEDIOCREDITO TRENTINO-ALTO ADIGE - S.P.A.",
-    "short_name": "MEDIOCREDITO TRENTINO-ALTO ADIGE - S.P.A."
+    "bank_code": "08252",
+    "name": "CASSA RURALE CENTRO VALSUGANA DI SPERA, STRIGNO, TELVE - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RURALE CENTRO VALSUGANA DI SPERA, STRIGNO, TELVE - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -82,7 +58,39 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRR760",
+    "bic": "UNCRITMM",
+    "bank_code": "03135",
+    "name": "UNICREDIT, SOCIETA' PER AZIONI",
+    "short_name": "UNICREDIT, SOCIETA' PER AZIONI"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "07058",
+    "name": "BANCA REGGIANA CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
+    "short_name": "BANCA REGGIANA CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITR1",
+    "bank_code": "08852",
+    "name": "ROMAGNA EST BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "ROMAGNA EST BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TBDB",
+    "bank_code": "08883",
+    "name": "BANCA DI BOLOGNA CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI BOLOGNA CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
     "bank_code": "08258",
     "name": "CREDITO COOPERATIVO CENTRO CALABRIA - SOCIETA' COOPERATIVA",
     "short_name": "CREDITO COOPERATIVO CENTRO CALABRIA - SOCIETA' COOPERATIVA"
@@ -178,10 +186,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ABCOITMM",
+    "bic": "SBOSITML",
     "bank_code": "03561",
-    "name": "ARAB BANKING CORPORATION SA",
-    "short_name": "ARAB BANKING CORPORATION SA"
+    "name": "ABC INTERNATIONAL BANK PLC",
+    "short_name": "ABC INTERNATIONAL BANK PLC"
   },
   {
     "country_code": "IT",
@@ -202,14 +210,6 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ARTCITR1",
-    "bank_code": "10681",
-    "name": "ARTIGIANCASSA S.P.A.",
-    "short_name": "ARTIGIANCASSA S.P.A."
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
     "bic": "CASRIT22",
     "bank_code": "06085",
     "name": "CASSA DI RISPARMIO DI ASTI S.P.A.",
@@ -226,10 +226,18 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "UNCRITMM",
+    "bank_code": "02008",
+    "name": "UNICREDIT BANCA S.P.A.",
+    "short_name": "UNICREDIT BANCA S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "PASCITMM",
-    "bank_code": "01030",
-    "name": "BANCA MONTE DEI PASCHI DI SIENA S.P.A.",
-    "short_name": "BANCA MONTE DEI PASCHI DI SIENA S.P.A."
+    "bank_code": "05040",
+    "name": "BANCA ANTONVENETA S.P.A.",
+    "short_name": "ANTONVENETA S.P.A."
   },
   {
     "country_code": "IT",
@@ -258,6 +266,22 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "ICRAITRRQF0",
+    "bank_code": "08951",
+    "name": "\"BANCA DI CREDITO COOPERATIVO \"GIUSEPPE TONIOLO\" DI GENZANO SOCIETA' COOPERATIVA\"",
+    "short_name": "\"BANCA DI CREDITO COOPERATIVO \"GIUSEPPE TONIOLO\" DI GENZANO SOCIETA' COOPERATIVA\""
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T",
+    "bank_code": "08982",
+    "name": "BANCA ADRIA COLLI EUGANEI - CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
+    "short_name": "BANCA ADRIA COLLI EUGANEI - CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "CCRTIT2T06A",
     "bank_code": "08026",
     "name": "CASSA RURALE DI LEDRO - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
@@ -267,25 +291,41 @@
     "country_code": "IT",
     "primary": true,
     "bic": "CCRTIT21",
-    "bank_code": "08344",
-    "name": "BANCA DI CREDITO COOPERATIVO DI ANAGNI SOCIETA' COOPERATIVA",
-    "short_name": "BANCANAGNI CREDITO COOPERATIVO"
+    "bank_code": "08016",
+    "name": "CASSA RURALE ALTOGARDA - ROVERETO - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RURALE ALTOGARDA - ROVERETO - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRQF0",
-    "bank_code": "08951",
-    "name": "\"BANCA DI CREDITO COOPERATIVO \"GIUSEPPE TONIOLO\" DI GENZANO SOCIETA' COOPERATIVA\"",
-    "short_name": "\"BANCA DI CREDITO COOPERATIVO \"GIUSEPPE TONIOLO\" DI GENZANO SOCIETA' COOPERATIVA\""
+    "bic": "BPMOIT22",
+    "bank_code": "05392",
+    "name": "Banca Popolare dell Emilia Romagna",
+    "short_name": "Banca Popolare dell Emilia Romagna"
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2T97A",
-    "bank_code": "08982",
-    "name": "BANCA ADRIA COLLI EUGANEI - CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
-    "short_name": "BANCA ADRIA COLLI EUGANEI - CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
+    "bic": "BLOPIT22",
+    "bank_code": "03067",
+    "name": "Unione Di Banche Italiane SpA",
+    "short_name": "Unione Di Banche Italiane SpA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BLOPIT22",
+    "bank_code": "05608",
+    "name": "UBI Banca S.p.A.",
+    "short_name": "UBI Banca S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "PASCITMM",
+    "bank_code": "01030",
+    "name": "BANCA MONTE DEI PASCHI DI SIENA S.P.A.",
+    "short_name": "BANCA MONTE DEI PASCHI DI SIENA S.P.A."
   },
   {
     "country_code": "IT",
@@ -294,6 +334,14 @@
     "bank_code": "07601",
     "name": "Poste Italiane SpA",
     "short_name": "Poste Italiane SpA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "01025",
+    "name": "SANPAOLO IMI S.P.A.",
+    "short_name": "SANPAOLO IMI S.P.A."
   },
   {
     "country_code": "IT",
@@ -315,9 +363,25 @@
     "country_code": "IT",
     "primary": true,
     "bic": "CCRTIT2TCRT",
-    "bank_code": "03002",
-    "name": "BANCA DI ROMA, SOCIETA' PER AZIONI",
-    "short_name": "BANCA DI ROMA, SOCIETA' PER AZIONI"
+    "bank_code": "07092",
+    "name": "BANCA DI CREDITO COOPERATIVO DEI CASTELLI ROMANI E DEL TUSCOLO - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DEI CASTELLI ROMANI E DEL TUSCOLO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08189",
+    "name": "BANCA DI CREDITO COOPERATIVO DELLA VALLE DEL TRIGNO - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DELLA VALLE DEL TRIGNO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT21",
+    "bank_code": "08407",
+    "name": "BANCA DI CREDITO COOPERATIVO DEL VENEZIANO - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DEL VENEZIANO - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -334,6 +398,22 @@
     "bank_code": "08631",
     "name": "BANCA 360 CREDITO COOPERATIVO FVG  - SOCIETA' COOPERATIVA",
     "short_name": "BANCA 360 CREDITO COOPERATIVO FVG  - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T",
+    "bank_code": "08616",
+    "name": "BANCA ADIGE PO CREDITO COOPERATIVO LUSIA - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA ADIGE PO CREDITO COOPERATIVO LUSIA - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T97A",
+    "bank_code": "08610",
+    "name": "Banca Adria - Credito\nCooperativo del Delta",
+    "short_name": "Banca Adria - Credito\nCooperativo del Delta"
   },
   {
     "country_code": "IT",
@@ -355,14 +435,14 @@
     "country_code": "IT",
     "primary": true,
     "bic": "AIDEITM2",
-    "bank_code": "03059",
-    "name": "BANCA CIS S.P.A.",
-    "short_name": "BANCA CIS S.P.A."
+    "bank_code": "03625",
+    "name": "BANCA AIDEXA S.P.A.",
+    "short_name": "BANCA AIDEXA S.P.A."
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRUO0",
+    "bic": "ICRAITRR",
     "bank_code": "07104",
     "name": "BANCA DI CREDITO COOPERATIVO - BANCA DI SIRACUSA",
     "short_name": "BCC BANCA DI SIRACUSA - SOCIETA' COOPERATIVA"
@@ -379,9 +459,9 @@
     "country_code": "IT",
     "primary": true,
     "bic": "IFISIT2V",
-    "bank_code": "10685",
-    "name": "GE CAPITAL INTERBANCA S.P.A.",
-    "short_name": "GE CAPITAL INTERBANCA S.P.A."
+    "bank_code": "03205",
+    "name": "BANCA IFIS S.P.A. (OVVERO IFIS BANCA S.P.A.",
+    "short_name": "IFIS S.P.A."
   },
   {
     "country_code": "IT",
@@ -410,7 +490,15 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT21N13",
+    "bic": "BCITITMM",
+    "bank_code": "03069",
+    "name": "INTESA SANPAOLO S.P.A.",
+    "short_name": "INTESA SANPAOLO S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT21",
     "bank_code": "08344",
     "name": "BANCA DI CREDITO COOPERATIVO DI ANAGNI SOCIETA' COOPERATIVA",
     "short_name": "BANCANAGNI CREDITO COOPERATIVO"
@@ -418,7 +506,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRR900",
+    "bic": "ICRAITRR",
     "bank_code": "08517",
     "name": "BANCA DI CREDITO COOPERATIVO DI CRETA - CREDITO COOPERATIVO PIACENTINO - SOCIETA' COOPERATIVA",
     "short_name": "BANCA DI CREDITO COOPERATIVO DI CRETA - CREDITO COOPERATIVO PIACENTINO - SOCIETA' COOPERATIVA"
@@ -426,7 +514,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2TH00",
+    "bic": "CCRTIT2T",
     "bank_code": "08692",
     "name": "BANCA DI CREDITO COOPERATIVO DI BRESCIA - SOCIETA' COOPERATIVA",
     "short_name": "BCC BRESCIA - SOCIETA' COOPERATIVA"
@@ -434,7 +522,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITR1953",
+    "bic": "ICRAITR1",
     "bank_code": "08329",
     "name": "BANCA DI CREDITO COOPERATIVO DELL'ALTA BRIANZA - ALZATE BRIANZA",
     "short_name": "BANCA DI CREDITO COOPERATIVO DELL'ALTA BRIANZA - ALZATE BRIANZA"
@@ -450,7 +538,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2147L",
+    "bic": "CCRTIT21",
     "bank_code": "08178",
     "name": "CASSA RURALE ALTA VALSUGANA - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
     "short_name": "CASSA RURALE ALTA VALSUGANA - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
@@ -474,10 +562,34 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "01010",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "BLEAITM1",
     "bank_code": "03026",
     "name": "BANCA ITALEASE S.P.A.",
     "short_name": "BANCA ITALEASE S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "05748",
+    "name": "BANCA DELL'ADRIATICO S.P.A.",
+    "short_name": "BANCA DELL'ADRIATICO S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06345",
+    "name": "INTESA SANPAOLO SPA",
+    "short_name": "INTESA SANPAOLO SPA"
   },
   {
     "country_code": "IT",
@@ -498,10 +610,26 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITR1OLH",
+    "bic": "BCITITMM",
+    "bank_code": "06315",
+    "name": "CASSE DI RISPARMIO DELL'UMBRIA S.P.A.",
+    "short_name": "CASSE DI RISPARMIO DELL'UMBRIA S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITR1",
     "bank_code": "08885",
     "name": "BCC Umbria Credito Cooperativo - societ\u00e0 cooperativa",
     "short_name": "BCC Umbria Credito Cooperativo - societ\u00e0 cooperativa"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITR1",
+    "bank_code": "08324",
+    "name": "BANCA CENTROPADANA CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA CENTROPADANA CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -510,6 +638,14 @@
     "bank_code": "03084",
     "name": "BANCA CESARE PONTI S.P.A.",
     "short_name": "BANCA CESARE PONTI S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06160",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
   },
   {
     "country_code": "IT",
@@ -530,6 +666,30 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06010",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06385",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BLOPIT22",
+    "bank_code": "05428",
+    "name": "Unione Di Banche Italiane SpA",
+    "short_name": "Unione Di Banche Italiane SpA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "CFIUITR2",
     "bank_code": "10312",
     "name": "BANCA CF+ CREDITO FONDIARIO S.P.A.",
@@ -538,10 +698,42 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "CCRTIT21",
+    "bank_code": "03599",
+    "name": "CASSA CENTRALE BANCA - CREDITO COOPERATIVO ITALIANOSOCIETA' PER AZIONI",
+    "short_name": "CASSA CENTRALE BANCA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08000",
+    "name": "ICCREA BANCA S.P.A. - ISTITUTO CENTRALE DEL CREDITO COOPERATIVO",
+    "short_name": "ICCREA BANCA S.P.A. - ISTITUTO CENTRALE DEL CREDITO COOPERATIVO"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "FARBIT22",
     "bank_code": "03110",
     "name": "BANCA CREDIFARMA S.P.A.",
     "short_name": "BANCA CREDIFARMA S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08428",
+    "name": "BANCA DI CREDITO COOPERATIVO DI CAMPIGLIA DEI BERICI - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DI CAMPIGLIA DEI BERICI - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TIBL",
+    "bank_code": "07078",
+    "name": "BANCA DI CREDITO COOPERATIVO DEI CASTELLI E DEGLI IBLEI SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DEI CASTELLI E DEGLI IBLEI SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -562,10 +754,34 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BPMOIT22",
+    "bank_code": "05256",
+    "name": "BANCA POPOLARE DI CROTONE - SOCIETA' PER AZIONI",
+    "short_name": "BANCA POPOLARE DI CROTONE - SOCIETA' PER AZIONI"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "BDCPITTT",
     "bank_code": "03048",
     "name": "BANCA DEL PIEMONTE S.P.A.",
     "short_name": "BANCA DEL PIEMONTE S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08592",
+    "name": "BANCA DI CREDITO COOPERATIVO DI INZAGO - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DI INZAGO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BPBAIT3B",
+    "bank_code": "05424",
+    "name": "BDM BANCA S.P.A.",
+    "short_name": "BDM BANCA S.P.A."
   },
   {
     "country_code": "IT",
@@ -578,7 +794,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT21G03",
+    "bic": "CCRTIT21",
     "bank_code": "08986",
     "name": "BANCA DEL VENETO CENTRALE - CREDITO COOPERATIVO SOC. COOP",
     "short_name": "BANCA DEL VENETO CENTRALE - CREDITO COOPERATIVO SOC. COOP"
@@ -586,10 +802,50 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRLF0",
+    "bic": "CCRTIT21",
+    "bank_code": "08669",
+    "name": "BVR BANCA VENETO CENTRALE - CREDITO COOPERATIVO ITALIANO S.C.",
+    "short_name": "BVR BANCA VENETO CENTRALE - CREDITO COOPERATIVO ITALIANO S.C."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
     "bank_code": "08771",
     "name": "CREDITO COOPERATIVO DELL'ADDA E DEL CREMASCO",
     "short_name": "CREDITO COOPERATIVO DELL'ADDA E DEL CREMASCO"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TCRT",
+    "bank_code": "08327",
+    "name": "BANCA DI CREDITO COOPERATIVO DI ROMA SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DI ROMA SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08515",
+    "name": "BANCA DELLA VALSASSINA CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DELLA VALSASSINA CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CIPBITMM",
+    "bank_code": "07067",
+    "name": "BANCA DELLA TUSCIA CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DELLA TUSCIA CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "07071",
+    "name": "BANCA DELLA VALSASSINA - CREDITO COOPERATIVO - SOCIETA' COOPERATIVA A RESPONSABILITA' LIMITATA",
+    "short_name": "BANCA DELLA VALSASSINA - CREDITO COOPERATIVO - SOCIETA' COOPERATIVA A RESPONSABILITA' LIMITATA"
   },
   {
     "country_code": "IT",
@@ -618,7 +874,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRRG0",
+    "bic": "ICRAITRR",
     "bank_code": "08988",
     "name": "BANCA DI CREDITO COOPERATIVO DEGLI ULIVI - TERRA DI BARI - SOCIETA' COOPERATIVA",
     "short_name": "BANCA DI CREDITO COOPERATIVO DEGLI ULIVI - TERRA DI BARI - SOCIETA' COOPERATIVA"
@@ -650,6 +906,14 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BLOPIT22",
+    "bank_code": "06055",
+    "name": "Unione Di Banche Italiane SpA",
+    "short_name": "Unione Di Banche Italiane SpA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "MICSITM1",
     "bank_code": "03058",
     "name": "MEDIOBANCA PREMIER S.P.A.",
@@ -658,31 +922,15 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRTR0",
-    "bank_code": "08899",
-    "name": "CASSA RURALE - BANCA DI CREDITO COOPERATIVO DI TREVIGLIO - SOCIETA' COOPERATIVA",
-    "short_name": "CASSA RURALE - BANCA DI CREDITO COOPERATIVO DI TREVIGLIO - SOCIETA' COOPERATIVA"
+    "bic": "BCITITMM",
+    "bank_code": "06280",
+    "name": "CR DI RIETI SPA",
+    "short_name": "CR DI RIETI SPA"
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRREB0",
-    "bank_code": "08515",
-    "name": "BANCA DELLA VALSASSINA CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
-    "short_name": "BANCA DELLA VALSASSINA CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "CCRTIT21F03",
-    "bank_code": "08669",
-    "name": "BVR BANCA - BANCHE VENETE RIUNITE - CREDITO COOPERATIVO DI SCHIO, PEDEMONTE, ROANA E VESTENANOVA - SOCIETA' COOPERATIVA",
-    "short_name": "BVR BANCA - BANCHE VENETE RIUNITE - CREDITO COOPERATIVO DI SCHIO, PEDEMONTE, ROANA E VESTENANOVA - SOCIETA' COOPERATIVA"
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "ICRAITRR2E0",
+    "bic": "ICRAITRR",
     "bank_code": "08086",
     "name": "BANCA DI CREDITO COOPERATIVO DI FALCONARA MARITTINA - SOCIETA' COOPERATIVA",
     "short_name": "BANCA DI CREDITO COOPERATIVO DI FALCONARA MARITTINA - SOCIETA' COOPERATIVA"
@@ -690,10 +938,18 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRPG0",
+    "bic": "ICRAITRR",
     "bank_code": "08916",
     "name": "BANCA DI ANCONA, CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
     "short_name": "BANCA DI ANCONA, CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BLOPIT22",
+    "bank_code": "05308",
+    "name": "Unione Di Banche Italiane SpA",
+    "short_name": "Unione Di Banche Italiane SpA"
   },
   {
     "country_code": "IT",
@@ -714,10 +970,66 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BLOPIT22",
+    "bank_code": "05048",
+    "name": "Unione Di Banche Italiane SpA",
+    "short_name": "Unione Di Banche Italiane SpA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "FICUITTT",
+    "bank_code": "03191",
+    "name": "SANTANDER CONSUMER BANK S.P.A.",
+    "short_name": "SANTANDER CONSUMER BANK S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "03359",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "IFISIT2V",
+    "bank_code": "10685",
+    "name": "GE CAPITAL INTERBANCA S.P.A.",
+    "short_name": "GE CAPITAL INTERBANCA S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "05035",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "10637",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "ICRAITRRTQ0",
     "bank_code": "07070",
     "name": "BANCA DI CESENA CREDITO COOPERATIVO DI CESENA E RONTA SCRL",
     "short_name": "BANCA DI CESENA CREDITO COOPERATIVO DI CESENA E RONTA SCRL"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08941",
+    "name": "BANCA DI CREDITO COOPERATIVO SAN MARCO DI CALATABIANO - SOCIETA' COOPERATIVA A RESPONSABILITA' LIMITATA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO SAN MARCO DI CALATABIANO - SOCIETA' COOPERATIVA A RESPONSABILITA' LIMITATA"
   },
   {
     "country_code": "IT",
@@ -730,18 +1042,18 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "BPBAIT3B",
-    "bank_code": "05424",
-    "name": "BANCA POPOLARE DI BARI - SOCIETA' COOPERATIVA PER AZIONI",
-    "short_name": "BANCA POPOLARE DI BARI - SOCIETA' COOPERATIVA PER AZIONI"
+    "bic": "CCRTIT2TALB",
+    "bank_code": "07087",
+    "name": "Banca di Credito Cooperativo di\nBari",
+    "short_name": "Banca di Credito Cooperativo di\nBari"
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRR59Z",
-    "bank_code": "08189",
-    "name": "BCC DELLA VALLE DEL TRIGNO SOCIETA' COOPERATIVA",
-    "short_name": "BCC DELLA VALLE DEL TRIGNO SOCIETA' COOPERATIVA"
+    "bic": "BLOPIT22",
+    "bank_code": "10633",
+    "name": "CENTROBANCA - BANCA DI CREDITO FINANZIARIO E MOBILIARE S.P.A.",
+    "short_name": "CENTROBANCA S.P.A."
   },
   {
     "country_code": "IT",
@@ -770,7 +1082,23 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRO90",
+    "bic": "FIDMIT31",
+    "bank_code": "03115",
+    "name": "FINDOMESTIC BANCA SPA",
+    "short_name": "FINDOMESTIC BANCA SPA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06225",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
     "bank_code": "08873",
     "name": "BANCA DI CREDITO COOPERATIVO APPULO LUCANA - SOCIETA' COOPERATIVA",
     "short_name": "BANCA DI CREDITO COOPERATIVO APPULO LUCANA - SOCIETA' COOPERATIVA"
@@ -778,18 +1106,42 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2TIBL",
-    "bank_code": "07078",
-    "name": "BANCA DI CREDITO COOPERATIVO DEI CASTELLI E DEGLI IBLEI SOCIETA' COOPERATIVA",
-    "short_name": "BANCA DI CREDITO COOPERATIVO DEI CASTELLI E DEGLI IBLEI SOCIETA' COOPERATIVA"
+    "bic": "BPMOIT22",
+    "bank_code": "05550",
+    "name": "BANCA POPOLARE DI LANCIANO E SULMONA SOCIETA' PER AZIONI",
+    "short_name": "BANCA POPOLARE DI LANCIANO E SULMONA SOCIETA' PER AZIONI"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06930",
+    "name": "BANCA MONTE PARMA SPA",
+    "short_name": "BANCA MONTE PARMA SPA"
   },
   {
     "country_code": "IT",
     "primary": true,
     "bic": "CCRTIT2T99A",
-    "bank_code": "07085",
-    "name": "CREDITO COOPERATIVO FRIULI SOCIETA' COOPERATIVA",
-    "short_name": "CREDITO COOPERATIVO FRIULI SOCIETA' COOPERATIVA"
+    "bank_code": "07083",
+    "name": "Banca di Credito Cooperativo del\nCirceo",
+    "short_name": "Banca di Credito Cooperativo del\nCirceo"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITR1",
+    "bank_code": "08970",
+    "name": "BANCA DI RIMINI CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI RIMINI CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "09008",
+    "name": "SANPAOLO BANCA DELL'ADRIATICO S.P.A.",
+    "short_name": "SANPAOLO BANCA DELL'ADRIATICO S.P.A."
   },
   {
     "country_code": "IT",
@@ -810,18 +1162,42 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2TROC",
-    "bank_code": "08462",
-    "name": "BANCA DI CREDITO COOPERATIVO DELLA ROMAGNA OCCIDENTALE - SOCIETA' COOPERATIVA",
-    "short_name": "BANCA DI CREDITO COOPERATIVO DELLA ROMAGNA OCCIDENTALE - SOCIETA' COOPERATIVA"
+    "bic": "BCITITMM",
+    "bank_code": "06065",
+    "name": "CASSA DI RISPARMIO DELLA PROVINCIA DI VITERBO S.P.A.",
+    "short_name": "CASSA DI RISPARMIO DELLA PROVINCIA DI VITERBO S.P.A."
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITR1NO9",
-    "bank_code": "08852",
-    "name": "ROMAGNA EST BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
-    "short_name": "ROMAGNA EST BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+    "bic": "ICRAITRR",
+    "bank_code": "07010",
+    "name": "BANCA DI CREDITO COOPERATIVO DI MAIERATO",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DI MAIERATO"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TROC",
+    "bank_code": "08462",
+    "name": "BCC DELLA ROMAGNA OCCIDENTALE SOCIETA' COOPERATIVA",
+    "short_name": "BCC DELLA ROMAGNA OCCIDENTALE SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TALB",
+    "bank_code": "08958",
+    "name": "Banca di Credito Cooperativo\nSan Giuseppe delle Madonie ",
+    "short_name": "Banca di Credito Cooperativo\nSan Giuseppe delle Madonie "
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08460",
+    "name": "BANCA DI CREDITO COOPERATIVO DI CASSANO DELLE MURGE E TOLVE - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DI CASSANO DELLE MURGE E TOLVE - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -830,14 +1206,6 @@
     "bank_code": "08078",
     "name": "CRU GIUDICARIE VALSABBIA PAGANELLA BCC SOCIETA' COOPERATIVA",
     "short_name": "CRU GIUDICARIE VALSABBIA PAGANELLA BCC SOCIETA' COOPERATIVA"
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "ICRAITRRCS0",
-    "bank_code": "08460",
-    "name": "BANCA DI CREDITO COOPERATIVO DI CASSANO DELLE MURGE E TOLVE - SOCIETA' COOPERATIVA",
-    "short_name": "BANCA DI CREDITO COOPERATIVO DI CASSANO DELLE MURGE E TOLVE - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -866,15 +1234,15 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "BCVAIT2V",
-    "bank_code": "05116",
-    "name": "BANCA VALSABBINA SOCIETA' COOPERATIVA PER AZIONI",
-    "short_name": "LA VALSABBINA"
+    "bic": "CCRTIT2TALB",
+    "bank_code": "08338",
+    "name": "BANCA DI CREDITO COOPERATIVO DI ALBEROBELLO, SAMMICHELE E MONOPOLI  - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DI ALBEROBELLO, SAMMICHELE E MONOPOLI  - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "BCVAIT2VCAF",
+    "bic": "BCVAIT2V",
     "bank_code": "05116",
     "name": "BANCA VALSABBINA SOCIETA' COOPERATIVA PER AZIONI",
     "short_name": "LA VALSABBINA"
@@ -898,7 +1266,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRAE0",
+    "bic": "ICRAITRR",
     "bank_code": "08374",
     "name": "BANCA DI CREDITO COOPERATIVO DI BARLASSINA",
     "short_name": "BANCA DI CREDITO COOPERATIVO DI BARLASSINA"
@@ -915,9 +1283,9 @@
     "country_code": "IT",
     "primary": true,
     "bic": "CCRTIT2TFEL",
-    "bank_code": "08331",
-    "name": "BCC Felsinea Banca di Credito\nCooperativo dal 1902",
-    "short_name": "BCC Felsinea Banca di Credito\nCooperativo dal 1902"
+    "bank_code": "08472",
+    "name": "BCC FELSINEA - BANCA DI CREDITO COOPERATIVO DAL1902 - SOCIETA' COOPERATIVA",
+    "short_name": "BCC FELSINEA - BANCA DI CREDITO COOPERATIVO DAL1902 - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -930,7 +1298,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRRN0",
+    "bic": "ICRAITRR",
     "bank_code": "08995",
     "name": "BCC VALMARECCHIA NEI COMUNI DI RIMINI E VERUCCHIO SOC. COOPERATIVA",
     "short_name": "BCC VALMARECCHIA NEI COMUNI DI RIMINI E VERUCCHIO SOC. COOPERATIVA"
@@ -946,18 +1314,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "FICUITTT",
-    "bank_code": "03191",
-    "name": "SANTANDER CONSUMER BANK S.P.A.",
-    "short_name": "SANTANDER CONSUMER BANK S.P.A."
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
     "bic": "BPCVIT2S",
-    "bank_code": "03041",
-    "name": "UBS",
-    "short_name": "UBS"
+    "bank_code": "05216",
+    "name": "Credit Agricole Italia",
+    "short_name": "Credit Agricole Italia"
   },
   {
     "country_code": "IT",
@@ -979,17 +1339,41 @@
     "country_code": "IT",
     "primary": true,
     "bic": "BAECIT2B",
-    "bank_code": "06155",
+    "bank_code": "03127",
     "name": "BPER Banca S.p.A",
     "short_name": "BPER Banca S.p.A"
   },
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "03309",
+    "name": "BANCA INFRASTRUTTURE INNOVAZIONE E SVILUPPO S.P.A.",
+    "short_name": "BANCA INFRASTRUTTURE INNOVAZIONE E SVILUPPO S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "INGBITD1",
-    "bank_code": "03475",
-    "name": "ING BANK N.V.",
-    "short_name": "ING BANK N.V."
+    "bank_code": "03169",
+    "name": "ING Bank N.V.",
+    "short_name": "ING Bank N.V."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "05787",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08487",
+    "name": "BANCA DI CREDITO COOPERATIVO DI CHERASCO - SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DI CHERASCO - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -1018,6 +1402,22 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "CCRTIT2T",
+    "bank_code": "08622",
+    "name": "CREDITO COOPERATIVO - CASSA RURALE ED ARTIGIANA DEL FRIULI VENEZIA GIULIA",
+    "short_name": "CREDITO COOPERATIVO - CASSA RURALE ED ARTIGIANA DEL FRIULI VENEZIA GIULIA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08083",
+    "name": "CASSA RURALE ED ARTIGIANA BANCA DI CREDITO COOPERATIVO DI FISCIANO - SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RURALE ED ARTIGIANA BANCA DI CREDITO COOPERATIVO DI FISCIANO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "CCRTIT2TBOV",
     "bank_code": "08397",
     "name": "CASSA RURALE ED ARTIGIANA DI BOVES - BANCA DI CREDITO COOPERATIVO",
@@ -1034,6 +1434,14 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "05132",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "IMCOIT2A",
     "bank_code": "03301",
     "name": "CASSA DEI RISPARMI DI MILANO E DELLA LOMBARDIA S.P.A.",
@@ -1046,6 +1454,22 @@
     "bank_code": "03211",
     "name": "BANCA PATRIMONI SELLA & C. S.P.A.",
     "short_name": "BPS S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BPMOIT22",
+    "bank_code": "05414",
+    "name": "BANCA POPOLARE DI APRILIA - S.P.A.",
+    "short_name": "BANCA POPOLARE DI APRILIA - S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "PASBITGG",
+    "bank_code": "03332",
+    "name": "BANCA PASSADORE & C. S.P.A.",
+    "short_name": "BANCA PASSADORE & C. S.P.A."
   },
   {
     "country_code": "IT",
@@ -1074,10 +1498,58 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BLOPIT22",
+    "bank_code": "05390",
+    "name": "Unione Di Banche Italiane SpA",
+    "short_name": "Unione Di Banche Italiane SpA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BDBDIT22",
+    "bank_code": "05704",
+    "name": "Banco di Desio e della Brianza S.P.A.",
+    "short_name": "Banco di Desio e della Brianza S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "CCRTIT2TSGR",
     "bank_code": "08810",
     "name": "BANCA DI CREDITO COOPERATIVO DI SAN GIOVANNI ROTONDO - SOCIETA' COOPERATIVA",
     "short_name": "BANCA DI CREDITO COOPERATIVO DI SAN GIOVANNI ROTONDO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCVAIT2V",
+    "bank_code": "03245",
+    "name": "CREVERBANCA S.P.A O CREDITO VERONESE S.P.A.",
+    "short_name": "CREVERBANCA S.P.A O CREDITO VERONESE S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TALB",
+    "bank_code": "08071",
+    "name": "Banca di Credito Cooperativo\nSan Giuseppe di Petralia Sottana ",
+    "short_name": "Banca di Credito Cooperativo\nSan Giuseppe di Petralia Sottana "
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08673",
+    "name": "CHIANTIBANCA - CREDITO COOPERATIVO S.C.",
+    "short_name": "CHIANTIBANCA - CREDITO COOPERATIVO S.C."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BLOPIT22",
+    "bank_code": "03500",
+    "name": "Unione Di Banche Italiane SpA",
+    "short_name": "Unione Di Banche Italiane SpA"
   },
   {
     "country_code": "IT",
@@ -1090,7 +1562,15 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRPX0",
+    "bic": "ICRAITRR",
+    "bank_code": "08452",
+    "name": "BANCA DI CREDITO COOPERATIVO DI VENEZIA, PADOVA E ROVIGO - BANCA ANNIA SOCIETA' COOPERATIVA",
+    "short_name": "BANCA DI CREDITO COOPERATIVO DI VENEZIA, PADOVA E ROVIGO - BANCA ANNIA SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
     "bank_code": "08933",
     "name": "BANCA DI CREDITO COOPERATIVO DEL POLESINE - ROVIGO",
     "short_name": "BANCA DI CREDITO COOPERATIVO DEL POLESINE - ROVIGO"
@@ -1106,6 +1586,14 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "07098",
+    "name": "Banca di Credito Cooperativo la\nRiscossa di Regalbuto",
+    "short_name": "Banca di Credito Cooperativo la\nRiscossa di Regalbuto"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "CCRTIT2TLAU",
     "bank_code": "08794",
     "name": "BANCA DI CREDITO COOPERATIVO LODI SOCIETA' COOPERATIVA",
@@ -1114,10 +1602,34 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2185G",
-    "bank_code": "08407",
-    "name": "BANCA DI CREDITO COOPERATIVO DEL VENEZIANO - SOCIETA' COOPERATIVA",
-    "short_name": "BANCA DI CREDITO COOPERATIVO DEL VENEZIANO - SOCIETA' COOPERATIVA"
+    "bic": "ICRAITRR",
+    "bank_code": "07074",
+    "name": "Banca di Credito Cooperativo Pordenonese",
+    "short_name": "Banca di Credito Cooperativo Pordenonese"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08807",
+    "name": "BCC DI VERONA E VICENZA - CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "BCC DI VERONA E VICENZA - CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "IMCOIT2A",
+    "bank_code": "05080",
+    "name": "BANCA DI IMOLA S.P.A.",
+    "short_name": "BANCA DI IMOLA S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BAECIT2B",
+    "bank_code": "06155",
+    "name": "BPER Banca S.p.A",
+    "short_name": "BPER Banca S.p.A"
   },
   {
     "country_code": "IT",
@@ -1130,6 +1642,14 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06260",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "BCPCIT2P",
     "bank_code": "05156",
     "name": "BANCA DI PIACENZA SCPA",
@@ -1138,10 +1658,42 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "BPPUIT31",
-    "bank_code": "05262",
-    "name": "BANCA POPOLARE PUGLIESE - SOCIETA' COOPERATIVA PER AZIONI",
-    "short_name": "BANCA POPOLARE PUGLIESE - SOCIETA' COOPERATIVA PER AZIONI"
+    "bic": "PASCITMM",
+    "bank_code": "05025",
+    "name": "BANCA FARNESE S.P.A.",
+    "short_name": "BANCA FARNESE S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T99A",
+    "bank_code": "07085",
+    "name": "CREDITO COOPERATIVO FRIULI SOCIETA' COOPERATIVA",
+    "short_name": "CREDITO COOPERATIVO FRIULI SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CIPBITMM",
+    "bank_code": "03259",
+    "name": "NORDEST BANCA S.P.A.",
+    "short_name": "NORDEST BANCA S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06340",
+    "name": "Intesa Sanpaolo S.p.A.",
+    "short_name": "Intesa Sanpaolo S.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT21",
+    "bank_code": "08088",
+    "name": "Cassa Rurale Alto Garda - Banca\ndi Credito Cooperativo",
+    "short_name": "Cassa Rurale Alto Garda - Banca\ndi Credito Cooperativo"
   },
   {
     "country_code": "IT",
@@ -1150,14 +1702,6 @@
     "bank_code": "03209",
     "name": "BANCA BSI ITALIA S.P.A.",
     "short_name": "BSI ITALIA S.P.A."
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "GAEOITM1",
-    "bank_code": "03267",
-    "name": "BANCA GALILEO S.P.A.",
-    "short_name": "BANCA GALILEO S.P.A."
   },
   {
     "country_code": "IT",
@@ -1202,7 +1746,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITR1E26",
+    "bic": "ICRAITR1",
     "bank_code": "07090",
     "name": "BANCA MALATESTIANA - CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
     "short_name": "BANCA MALATESTIANA - CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
@@ -1226,10 +1770,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "PASBITGG",
-    "bank_code": "03332",
-    "name": "BANCA PASSADORE & C. S.P.A.",
-    "short_name": "BANCA PASSADORE & C. S.P.A."
+    "bic": "BPMOIT22",
+    "bank_code": "05640",
+    "name": "Banca Popolare dell Emilia Romagna",
+    "short_name": "Banca Popolare dell Emilia Romagna"
   },
   {
     "country_code": "IT",
@@ -1238,6 +1782,30 @@
     "bank_code": "05584",
     "name": "BANCO BPM SPA",
     "short_name": "BANCO BPM SPA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T",
+    "bank_code": "08927",
+    "name": "CRA DI TREVISO CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
+    "short_name": "CRA DI TREVISO CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "SENVITT1XXX",
+    "bank_code": "03267",
+    "name": "Banca Patrimoni Sella & C.\nS.p.A.",
+    "short_name": "Banca Patrimoni Sella & C.\nS.p.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BPPUIT31",
+    "bank_code": "05262",
+    "name": "BANCA POPOLARE PUGLIESE - SOCIETA' COOPERATIVA PER AZIONI",
+    "short_name": "BANCA POPOLARE PUGLIESE - SOCIETA' COOPERATIVA PER AZIONI"
   },
   {
     "country_code": "IT",
@@ -1254,6 +1822,14 @@
     "bank_code": "05297",
     "name": "BANCA POPOLARE DEL FRUSINATE SOCIETA' COOPERATIVA PER AZIONI",
     "short_name": "BANCA POPOLARE DEL FRUSINATE SOCIETA' COOPERATIVA PER AZIONI"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TCRT",
+    "bank_code": "03002",
+    "name": "BANCA DI ROMA, SOCIETA' PER AZIONI",
+    "short_name": "BANCA DI ROMA, SOCIETA' PER AZIONI"
   },
   {
     "country_code": "IT",
@@ -1282,18 +1858,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "POSOIT2103B",
-    "bank_code": "05696",
-    "name": "BANCA POPOLARE DI SONDRIO SOCIETA' PER AZIONI",
-    "short_name": "BANCA POPOLARE DI SONDRIO SOCIETA' PER AZIONI"
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "BPPUIT31057",
-    "bank_code": "05262",
-    "name": "BANCA POPOLARE PUGLIESE - SOCIETA' COOPERATIVA PER AZIONI",
-    "short_name": "BANCA POPOLARE PUGLIESE - SOCIETA' COOPERATIVA PER AZIONI"
+    "bic": "CIPBITMM",
+    "bank_code": "03310",
+    "name": "ETICREDITO - BANCA ETICA ADRIATICA S.P.A.",
+    "short_name": "ETICREDITO - BANCA ETICA ADRIATICA S.P.A."
   },
   {
     "country_code": "IT",
@@ -1314,7 +1882,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRQT0",
+    "bic": "ICRAITRR",
     "bank_code": "08965",
     "name": "Banca Prealpi SanBiagio Credito Cooperativo - Societ\u00c3 Cooperativa",
     "short_name": "Banca Prealpi SanBiagio Credito Cooperativo - Societ\u00c3 Cooperativa"
@@ -1378,6 +1946,22 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "06130",
+    "name": "CR DI CIVITAVECCHIA SPA",
+    "short_name": "CR DI CIVITAVECCHIA SPA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "AIDEITM2",
+    "bank_code": "03059",
+    "name": "BANCA CIS S.P.A.",
+    "short_name": "BANCA CIS S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "SMSIIT21",
     "bank_code": "03398",
     "name": "BANCA SIMETICA S.P.A.",
@@ -1398,6 +1982,14 @@
     "bank_code": "03388",
     "name": "BANCA STABIESE - S.P.A.",
     "short_name": "BANCA STABIESE - S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BDBDIT22",
+    "bank_code": "03231",
+    "name": "BANCO DESIO LAZIO S.P.A.",
+    "short_name": "BANCO DESIO LAZIO S.P.A."
   },
   {
     "country_code": "IT",
@@ -1466,6 +2058,22 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08427",
+    "name": "CREDITO COOPERATIVO FIORENTINO - CAMPI BISENZIO - SOCIETA' COOPERATIVA",
+    "short_name": "CREDITO COOPERATIVO FIORENTINO - CAMPI BISENZIO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T",
+    "bank_code": "08491",
+    "name": "BANCO MARCHIGIANO CREDITO COOPERATIVO",
+    "short_name": "BANCO MARCHIGIANO CREDITO COOPERATIVO"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "BSCHITMM",
     "bank_code": "03389",
     "name": "BANCO SANTANDER S.A.",
@@ -1498,6 +2106,22 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "ARABITRR",
+    "bank_code": "03433",
+    "name": "BSI EUROPE S.A.",
+    "short_name": "BSI EUROPE S.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ARABITRR",
+    "bank_code": "23019",
+    "name": "H2O AM EUROPE",
+    "short_name": "H2O AM EUROPE"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "EDRSITM1XXX",
     "bank_code": "03407",
     "name": "EDMOND DE ROTHSCHILD",
@@ -1514,10 +2138,34 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "IRVTITMM",
+    "bank_code": "23004",
+    "name": "M&G LUXEMBOURG S.A.",
+    "short_name": "M&G LUXEMBOURG S.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "BCDMITM1",
     "bank_code": "03387",
     "name": "BANQUE CHAABI DU MAROC - IN ABBREVIATO, B.C.D.M.",
     "short_name": "BANQUE CHAABI DU MAROC - IN ABBREVIATO, B.C.D.M."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT21",
+    "bank_code": "03493",
+    "name": "CASSA CENTRALE RAIFFEISEN DELL'ALTO ADIGE - RAIFFEISEN-LANDESBANK SUEDTIROL A.G.",
+    "short_name": "CASSA CENTRALE RAIFFEISEN DELL'ALTO ADIGE - RAIFFEISEN-LANDESBANK SUEDTIROL A.G."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TFEL",
+    "bank_code": "08331",
+    "name": "BCC Felsinea Banca di Credito\nCooperativo dal 1902",
+    "short_name": "BCC Felsinea Banca di Credito\nCooperativo dal 1902"
   },
   {
     "country_code": "IT",
@@ -1530,6 +2178,14 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "BPBAIT3B",
+    "bank_code": "05037",
+    "name": "BDM BANCA S.P.A.",
+    "short_name": "BDM BANCA S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "CCRTIT2TBEN",
     "bank_code": "08382",
     "name": "BENE BANCA CREDITO COOPERATIVO DI BENE VAGIENNA",
@@ -1538,10 +2194,26 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CIPBITMMXXX",
+    "bic": "CIPBITMM",
     "bank_code": "05000",
     "name": "BFF BANK SPA",
     "short_name": "BFF BANK SPA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BCITITMM",
+    "bank_code": "03149",
+    "name": "BANCO EMILIANO ROMAGNOLO SPA",
+    "short_name": "BANCO EMILIANO ROMAGNOLO SPA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "PASCITMM",
+    "bank_code": "10643",
+    "name": "MPS CAPITAL SERVICES BANCA PER LE IMPRESE SPA",
+    "short_name": "MPS BANCA PER LE IMPRESE SPA"
   },
   {
     "country_code": "IT",
@@ -1550,22 +2222,6 @@
     "bank_code": "03165",
     "name": "IW BANK SPA",
     "short_name": "IW BANK SPA"
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "ESPEITMM",
-    "bank_code": "03183",
-    "name": "Mediobanca Banca di Credito\nFinanziario Spa ",
-    "short_name": "Mediobanca Banca di Credito\nFinanziario Spa "
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "CRFIIT2S",
-    "bank_code": "06030",
-    "name": "CREDIT AGRICOLE CARIPARMA SPA",
-    "short_name": "CREDIT AGRICOLE CARIPARMA SPA"
   },
   {
     "country_code": "IT",
@@ -1579,9 +2235,25 @@
     "country_code": "IT",
     "primary": true,
     "bic": "SBOSITML",
-    "bank_code": "36054",
-    "name": "DEX INTERNATIONAL LIMITED",
-    "short_name": "DEX INTERNATIONAL LIMITED"
+    "bank_code": "03243",
+    "name": "STATE STREET BANK GMBH",
+    "short_name": "STATE STREET BANK GMBH"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "SBOSITML",
+    "bank_code": "03439",
+    "name": "STATE STREET BANK GMBH",
+    "short_name": "STATE STREET BANK GMBH"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "TRBKITMMXXX",
+    "bank_code": "03674",
+    "name": "TRADE REPUBLIC BANK GMBH",
+    "short_name": "TRADE REPUBLIC BANK GMBH"
   },
   {
     "country_code": "IT",
@@ -1590,6 +2262,30 @@
     "bank_code": "03179",
     "name": "BNP PARIBAS LEASE GROUP",
     "short_name": "BNP PARIBAS LEASE GROUP"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BNPAITMM",
+    "bank_code": "03181",
+    "name": "BNP PARIBAS",
+    "short_name": "BNP PARIBAS"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BAECIT2B",
+    "bank_code": "06095",
+    "name": "BPER Banca S.p.A",
+    "short_name": "BPER Banca S.p.A"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BAECIT2B",
+    "bank_code": "06295",
+    "name": "BPER Banca S.p.A",
+    "short_name": "BPER Banca S.p.A"
   },
   {
     "country_code": "IT",
@@ -1658,10 +2354,26 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2101B",
+    "bic": "CSRFITR1",
+    "bank_code": "03140",
+    "name": "MPS BANCA PERSONALE S.P.A.",
+    "short_name": "MPS BANCA PERSONALE S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT21",
     "bank_code": "08011",
-    "name": "CASSA RURALE BASSA VALLAGARINA BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
-    "short_name": "CASSA RURALE BASSA VALLAGARINA BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+    "name": "CASSA RURALE VALLAGARINA - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RURALE VALLAGARINA - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT21",
+    "bank_code": "08091",
+    "name": "Cassa Rurale Bassa Vallagarina -\nBanca di Credito Cooperativo",
+    "short_name": "Cassa Rurale Bassa Vallagarina -\nBanca di Credito Cooperativo"
   },
   {
     "country_code": "IT",
@@ -1691,17 +2403,49 @@
     "country_code": "IT",
     "primary": true,
     "bic": "RZSBIT2B",
-    "bank_code": "08161",
-    "name": "CASSA RAIFFEISEN NOVA LEVANTE SOCIETA' COOPERATIVA",
-    "short_name": "CASSA RAIFFEISEN NOVA LEVANTE SOCIETA' COOPERATIVA"
+    "bank_code": "08035",
+    "name": "CASSA RAIFFEISEN DI BRUNICO SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RAIFFEISEN DI BRUNICO SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRR3P0",
+    "bic": "RZSBIT2B",
+    "bank_code": "08112",
+    "name": "CASSA RAIFFEISEN DI LAGUNDO SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RAIFFEISEN DI LAGUNDO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
     "bank_code": "08133",
     "name": "CASSA RAIFFEISEN MERANO SOCIETA' COOPERATIVA",
     "short_name": "CASSA RAIFFEISEN MERANO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "RZSBIT2B",
+    "bank_code": "08135",
+    "name": "CASSA RAIFFEISEN DI MELTINA SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RAIFFEISEN DI MELTINA SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "RZSBIT2B",
+    "bank_code": "08155",
+    "name": "CASSA RAIFFEISEN DI NALLES SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RAIFFEISEN DI NALLES SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "RZSBIT2B",
+    "bank_code": "08161",
+    "name": "CASSA RAIFFEISEN NOVA LEVANTE SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RAIFFEISEN NOVA LEVANTE SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -1714,10 +2458,34 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "RZSBIT2B",
+    "bank_code": "08281",
+    "name": "CASSA RAIFFEISEN DI TUBRE SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RAIFFEISEN DI TUBRE SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "RZSBIT2B",
+    "bank_code": "08015",
+    "name": "CASSA RAIFFEISEN DI ANDRIANO SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RAIFFEISEN DI ANDRIANO SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "RZSBIT21610",
     "bank_code": "08065",
     "name": "CASSA RAIFFEISEN SCHLERN - ROSENGARTEN SOCIETA' COOPERATIVA",
     "short_name": "CASSA RAIFFEISEN SCHLERN - ROSENGARTEN SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "RZSBIT2B",
+    "bank_code": "08295",
+    "name": "CASSA RAIFFEISEN DI VANDOIES SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RAIFFEISEN DI VANDOIES SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -1738,10 +2506,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2T73A",
-    "bank_code": "08079",
-    "name": "Cassa Rurale di Tuenno - Val di\nNon - Banca di Credito\nCooperativo - Societa",
-    "short_name": "Cassa Rurale di Tuenno - Val di\nNon - Banca di Credito\nCooperativo - Societa"
+    "bic": "ICRAITRRTR0",
+    "bank_code": "08899",
+    "name": "CASSA RURALE - BANCA DI CREDITO COOPERATIVO DI TREVIGLIO - SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RURALE - BANCA DI CREDITO COOPERATIVO DI TREVIGLIO - SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -1754,7 +2522,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2127S",
+    "bic": "CCRTIT21",
     "bank_code": "08102",
     "name": "CASSA RUR. VALSUGANA E TESINO BCC SC",
     "short_name": "CASSA RUR. VALSUGANA E TESINO BCC SC"
@@ -1762,10 +2530,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2104I",
-    "bank_code": "08016",
-    "name": "CASSA RURALE ALTOGARDA - ROVERETO - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
-    "short_name": "CASSA RURALE ALTOGARDA - ROVERETO - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+    "bic": "RZSBIT2B",
+    "bank_code": "08081",
+    "name": "CASSA RURALE DI BOLZANO SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RURALE DI BOLZANO SOCIETA' COOPERATIVA"
   },
   {
     "country_code": "IT",
@@ -1778,6 +2546,46 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08469",
+    "name": "CASSA RURALE ED ARTIGIANA DI CASTELLANA GROTTE CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RURALE ED ARTIGIANA DI CASTELLANA GROTTE CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T73A",
+    "bank_code": "08079",
+    "name": "Cassa Rurale di Tuenno - Val di\nNon - Banca di Credito\nCooperativo - Societa",
+    "short_name": "Cassa Rurale di Tuenno - Val di\nNon - Banca di Credito\nCooperativo - Societa"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T73A",
+    "bank_code": "08263",
+    "name": "Cassa Rurale di Tuenno - Val di Non - Banca di Credito Cooperativo - Societa",
+    "short_name": "Cassa Rurale di Tuenno - Val di Non - Banca di Credito Cooperativo - Societa"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T73A",
+    "bank_code": "08264",
+    "name": "Cassa Rurale di Tuenno - Val di\nNon - Banca di Credito\nCooperativo - Societa",
+    "short_name": "Cassa Rurale di Tuenno - Val di\nNon - Banca di Credito\nCooperativo - Societa"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2T",
+    "bank_code": "08055",
+    "name": "CASSA RURALE DI CASTELLO TESINO - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
+    "short_name": "CASSA RURALE DI CASTELLO TESINO - BANCA DI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "CCRTIT2TCAS",
     "bank_code": "08461",
     "name": "CASTAGNETO BANCA 1910 - CREDITO COOPERATIVO - S.C.",
@@ -1786,15 +2594,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2T94A",
-    "bank_code": "08927",
-    "name": "CRA DI TREVISO CREDITO COOPERATIVO SOCIETA' COOPERATIVA",
-    "short_name": "CRA DI TREVISO CREDITO COOPERATIVO SOCIETA' COOPERATIVA"
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "ICRAITRRRI0",
+    "bic": "ICRAITRR",
     "bank_code": "08990",
     "name": "CentroMarca Banca - Credito Cooperativo",
     "short_name": "CentroMarca Banca - Credito Cooperativo"
@@ -1806,14 +2606,6 @@
     "bank_code": "03643",
     "name": "CHEBANCA! S.P.A.",
     "short_name": "CHEBANCA! S.P.A."
-  },
-  {
-    "country_code": "IT",
-    "primary": true,
-    "bic": "ICRAITRRIP0",
-    "bank_code": "08673",
-    "name": "CHIANTIBANCA - CREDITO COOPERATIVO S.C.",
-    "short_name": "CHIANTIBANCA - CREDITO COOPERATIVO S.C."
   },
   {
     "country_code": "IT",
@@ -1842,10 +2634,26 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CRESITMM",
-    "bank_code": "03089",
-    "name": "CREDIT SUISSE",
-    "short_name": "CREDIT SUISSE"
+    "bic": "ESPEITMM",
+    "bank_code": "03183",
+    "name": "Mediobanca Banca di Credito\nFinanziario Spa ",
+    "short_name": "Mediobanca Banca di Credito\nFinanziario Spa "
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "BPCVIT2S",
+    "bank_code": "03432",
+    "name": "CREDIT AGRICOLE CORPORATE & INVESTMENT BANK",
+    "short_name": "CREDIT AGRICOLE CORPORATE & INVESTMENT BANK"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CRFIIT2S",
+    "bank_code": "06030",
+    "name": "CREDIT AGRICOLE CARIPARMA SPA",
+    "short_name": "CREDIT AGRICOLE CARIPARMA SPA"
   },
   {
     "country_code": "IT",
@@ -1858,18 +2666,34 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRTI0",
-    "bank_code": "07062",
-    "name": "CREDITO COOPERATIVO MEDIOCRATI S.C. A R.L.",
-    "short_name": "CREDITO COOPERATIVO MEDIOCRATI S.C. A R.L."
+    "bic": "UNCRITMM",
+    "bank_code": "10639",
+    "name": "UNICREDIT CREDIT MANAGEMENT BANK S.P.A.",
+    "short_name": "UNICREDIT CREDIT MANAGEMENT BANK S.P.A."
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "BACRIT22",
-    "bank_code": "03032",
-    "name": "CREDITO EMILIANO S.P.A.",
-    "short_name": "CREDITO EMILIANO S.P.A."
+    "bic": "ICRAITR1",
+    "bank_code": "08578",
+    "name": "RiminiBanca - Credito coop.vo di Rimini e Valmarecchia s.c.",
+    "short_name": "RiminiBanca - Credito coop.vo di Rimini e Valmarecchia s.c."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "08805",
+    "name": "BancaTer Credito cooperativo\nFVG",
+    "short_name": "BancaTer Credito cooperativo\nFVG"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
+    "bank_code": "07062",
+    "name": "CREDITO COOPERATIVO MEDIOCRATI SCRL",
+    "short_name": "CREDITO COOPERATIVO MEDIOCRATI SCRL"
   },
   {
     "country_code": "IT",
@@ -1882,7 +2706,23 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITRRTS0",
+    "bic": "BAPPIT22",
+    "bank_code": "05630",
+    "name": "BANCA NETWORK INVESTIMENTI - SOCIETA' PER AZIONI",
+    "short_name": "BNI S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "SBOSITML",
+    "bank_code": "36054",
+    "name": "DEX INTERNATIONAL LIMITED",
+    "short_name": "DEX INTERNATIONAL LIMITED"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITRR",
     "bank_code": "07072",
     "name": "EMIL BANCA - CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
     "short_name": "EMIL BANCA - CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
@@ -1898,10 +2738,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "FIDMIT31",
-    "bank_code": "03115",
-    "name": "FINDOMESTIC BANCA SPA",
-    "short_name": "FINDOMESTIC BANCA SPA"
+    "bic": "FIBKITMM",
+    "bank_code": "03296",
+    "name": "FIDEURAM - INTESA SANPAOLO PRIVATE BANKING S.P.A.",
+    "short_name": "FIDEURAM - INTESA SANPAOLO PRIVATE BANKING S.P.A."
   },
   {
     "country_code": "IT",
@@ -1910,6 +2750,14 @@
     "bank_code": "03151",
     "name": "HYPO TIROL BANK ITALIA S.P.A.",
     "short_name": "HYPO TIROL BANK ITALIA S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ISCSITRR",
+    "bank_code": "10630",
+    "name": "ISTITUTO PER IL CREDITO SPORTIVO - ENTE DI DIRITTO PUBBLICO",
+    "short_name": "ISTITUTO PER IL CREDITO SPORTIVO - ENTE DI DIRITTO PUBBLICO"
   },
   {
     "country_code": "IT",
@@ -1930,18 +2778,18 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "INGBITMM",
-    "bank_code": "03339",
-    "name": "ING REAL ESTATE FINANCE S.E.,E.F.C.,S.A.",
-    "short_name": "ING REAL ESTATE FINANCE S.E.,E.F.C.,S.A."
+    "bic": "INGBITD1",
+    "bank_code": "03475",
+    "name": "ING BANK N.V.",
+    "short_name": "ING BANK N.V."
   },
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ISCSITRR",
-    "bank_code": "10630",
-    "name": "ISTITUTO PER IL CREDITO SPORTIVO - ENTE DI DIRITTO PUBBLICO",
-    "short_name": "ISTITUTO PER IL CREDITO SPORTIVO - ENTE DI DIRITTO PUBBLICO"
+    "bic": "INGBITMM",
+    "bank_code": "03339",
+    "name": "ING REAL ESTATE FINANCE S.E.,E.F.C.,S.A.",
+    "short_name": "ING REAL ESTATE FINANCE S.E.,E.F.C.,S.A."
   },
   {
     "country_code": "IT",
@@ -1970,10 +2818,18 @@
   {
     "country_code": "IT",
     "primary": true,
+    "bic": "SEPFIT31",
+    "bank_code": "03222",
+    "name": "SGB FINANCE S.A.",
+    "short_name": "SGB FINANCE S.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
     "bic": "KREDITMM",
     "bank_code": "03373",
-    "name": "KBC BANK N.V. ITALIA",
-    "short_name": "KBC BANK N.V. ITALIA"
+    "name": "KBC BANK N.V.",
+    "short_name": "KBC BANK N.V."
   },
   {
     "country_code": "IT",
@@ -2002,7 +2858,7 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "CCRTIT2TM00",
+    "bic": "CCRTIT2T",
     "bank_code": "10638",
     "name": "MEDIOCREDITO TRENTINO-ALTO ADIGE - S.P.A.",
     "short_name": "MEDIOCREDITO TRENTINO-ALTO ADIGE - S.P.A."
@@ -2018,10 +2874,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "MHCBITMM",
-    "bank_code": "03346",
-    "name": "MIZUHO BANK LIMITED",
-    "short_name": "MIZUHO BANK LIMITED"
+    "bic": "UBSWITMM",
+    "bank_code": "03630",
+    "name": "UBS LIMITED",
+    "short_name": "UBS LIMITED"
   },
   {
     "country_code": "IT",
@@ -2034,10 +2890,10 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITR1QY3",
-    "bank_code": "08970",
-    "name": "BANCA DI RIMINI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA",
-    "short_name": "BANCA DI RIMINI CREDITO COOPERATIVO - SOCIETA' COOPERATIVA"
+    "bic": "REVOITM2XXX",
+    "bank_code": "03669",
+    "name": "REVOLUT BANK UAB",
+    "short_name": "REVOLUT BANK UAB"
   },
   {
     "country_code": "IT",
@@ -2046,6 +2902,14 @@
     "bank_code": "03593",
     "name": "SOCIETE' GENERALE",
     "short_name": "SOCIETE' GENERALE"
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "UNCRITMM",
+    "bank_code": "03131",
+    "name": "UNICREDIT BANCA MOBILIARE S.P.A.",
+    "short_name": "U.B.M.S.P.A."
   },
   {
     "country_code": "IT",
@@ -2066,10 +2930,26 @@
   {
     "country_code": "IT",
     "primary": true,
-    "bic": "ICRAITR1NND",
+    "bic": "SBOSITML",
+    "bank_code": "03163",
+    "name": "STATE STREET BANK S.P.A.",
+    "short_name": "STATE STREET BANK S.P.A."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "ICRAITR1",
     "bank_code": "08851",
     "name": "TERRE ETRUSCHE DI VALDICHIANA E DI MAREMMA - CREDITO COOPERATIVO- S.C.",
     "short_name": "TERRE ETRUSCHE DI VALDICHIANA E DI MAREMMA - CREDITO COOPERATIVO- S.C."
+  },
+  {
+    "country_code": "IT",
+    "primary": true,
+    "bic": "CCRTIT2TV00",
+    "bank_code": "08532",
+    "name": "Banca di Credito Cooperativo del Carso",
+    "short_name": "Banca di Credito Cooperativo del Carso"
   },
   {
     "country_code": "IT",

--- a/scripts/get_bank_registry_it.py
+++ b/scripts/get_bank_registry_it.py
@@ -219,12 +219,12 @@ if __name__ == "__main__":
     runtime_test_split_bank_name()
 
     bank_names = sorted(set(get_italian_bank_names()))
-    bic_to_bank = {}
+    bank_code_to_bank = {}
     for i, bank_name in enumerate(bank_names):
         print(f"{i}/{len(bank_names)}", "- ", bank_name)
         banks = get_banks_registry_data_from_bank_name(bank_name)
         for bank in banks:
-            bic_to_bank[bank["bic"]] = bank
+            bank_code_to_bank[bank["bank_code"]] = bank
 
     with open("schwifty/bank_registry/generated_it.json", "w") as fp:
-        json.dump(list(bic_to_bank.values()), fp, indent=2)
+        json.dump(list(bank_code_to_bank.values()), fp, indent=2)


### PR DESCRIPTION
While using this useful library—primarily with Italian IBANs—I noticed that many banks were missing from the dataset. After inspecting the scraping logic, I saw that the source database actually contains **417** banks, but the resulting JSON only stores **260**.

The root cause seems to be the use of a map keyed by BIC to eliminate duplicates. However, in Italy, it's common for multiple banks (with different `ABI`/`bank_code` values) to share the same BIC. This causes several valid entries to be discarded unintentionally.

By switching the map key from `BIC` to `bank_code`, all banks provided in the source DB are now correctly retained in the output.

I hope this change aligns with the intended logic of the library. Let me know if anything needs clarification!