### PR TITLE
Add Paysafe Prepaid Services to IE bank registry

### DIFF
--- a/schwifty/bank_registry/manual_ie.json
+++ b/schwifty/bank_registry/manual_ie.json
@@ -222,5 +222,13 @@
     "name": "Revolut Bank UAB",
     "short_name": "Revolut Bank UAB",
     "primary": true
+  },
+  {
+    "country_code": "IE",
+    "bic": "PPSEIE22XXX",
+    "bank_code": "PPSE",
+    "name": "Paysafe Prepaid Services Limited",
+    "short_name": "Paysafe Prepaid Services",
+    "primary": true
   }
 ]


### PR DESCRIPTION
Adds PPSE (BIC: PPSEIE22XXX) for Paysafe Prepaid Services Limited to the IE manual bank registry.