### PR TITLE
Return True from validate_national_checksum on success

### DIFF
--- a/schwifty/bban.py
+++ b/schwifty/bban.py
@@ -251,7 +251,7 @@ class BBAN(common.Base):
         components = [self._get_component(component) for component in algo.accepts]
         if not algo.validate(components, self.national_checksum_digits):
             raise exceptions.InvalidBBANChecksum("Invalid national checksum")
-        return False
+        return True
 
     def _get_component(self, component_type: Component) -> str:
         position = _get_position_range(self.spec, component_type)

--- a/tests/test_bban.py
+++ b/tests/test_bban.py
@@ -1,6 +1,16 @@
 import pytest
 
 from schwifty.bban import BBAN
+from schwifty.exceptions import InvalidBBANChecksum
+
+
+def test_validate_national_checksum() -> None:
+    # A valid national checksum returns True (consistent with the "no checksum
+    # algorithm" case), while an invalid one raises InvalidBBANChecksum.
+    assert BBAN("BE", "539007547034").validate_national_checksum() is True
+    assert BBAN("GB", "WEST12345698765432").validate_national_checksum() is True
+    with pytest.raises(InvalidBBANChecksum):
+        BBAN("BE", "539007547035").validate_national_checksum()
 
 
 @pytest.mark.parametrize("country_code", ["DE", "ES", "GB", "FR", "PL"])


### PR DESCRIPTION
## Problem

`BBAN.validate_national_checksum()` returns `False` when the national checksum is **valid**:

```python
from schwifty import IBAN

IBAN("BE68539007547034").bban.validate_national_checksum()
# -> False   (a real, valid Belgian IBAN)
```

The method documents `-> bool` "Validate the national checksum digits" and raises `InvalidBBANChecksum` on an invalid checksum. So the boolean return is meant to signal validity. But the two "valid" outcomes disagree:

```python
if algo is None:
    return True      # no checksum algorithm => treated as valid
...
if not algo.validate(components, self.national_checksum_digits):
    raise exceptions.InvalidBBANChecksum("Invalid national checksum")
return False         # checksum actually passed -> but returns False
```

A country with no national-checksum algorithm (e.g. GB) returns `True`, while a country whose checksum *passes* (e.g. BE) returns `False` — contradictory for the same "valid" meaning.

## Fix

Return `True` on the success path, so the three outcomes are consistent: valid → `True`, no algorithm → `True`, invalid → raises `InvalidBBANChecksum`.

```python
IBAN("BE68539007547034").bban.validate_national_checksum()  # -> True
```

## Tests

Added `test_validate_national_checksum` in `tests/test_bban.py` asserting a valid checksum returns `True`, a country without an algorithm returns `True`, and an invalid checksum raises. It is RED on the current code (valid BBAN returns `False`) and GREEN with the fix; the full suite passes (395 passed). No existing test asserted this method's return value.

Disclosure: I prepared this fix with AI assistance under my direction; I reviewed and verified the change and the test myself.
