### PR TITLE
Fix BBAN pickle and deepcopy failures (#262)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ extend-ignore = [
 "scripts/get_*_registry*.py" = [
     "S113",   # Allow requests call without timeout
 ]
+"tests/test_bban.py" = [
+    "S301",   # pickle is safe when used with trusted own objects
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 15

--- a/schwifty/bban.py
+++ b/schwifty/bban.py
@@ -90,7 +90,8 @@ class BBAN(common.Base):
     def __init__(self, country_code: str, value: str) -> None:
         self.country_code = country_code
 
-    def __getnewargs__(self) -> tuple[str, str]:
+    # BBAN.__new__ needs both values when pickle reconstructs the object.
+    def __getnewargs__(self) -> tuple[str, str]:  # type: ignore[override]
         return (self.country_code, self.compact)
 
     def __deepcopy__(self, memo: dict[str, Any] | None = None) -> Self:

--- a/schwifty/bban.py
+++ b/schwifty/bban.py
@@ -90,6 +90,12 @@ class BBAN(common.Base):
     def __init__(self, country_code: str, value: str) -> None:
         self.country_code = country_code
 
+    def __getnewargs__(self) -> tuple[str, str]:
+        return (self.country_code, self.compact)
+
+    def __deepcopy__(self, memo: dict[str, Any] | None = None) -> Self:
+        return self.__class__(self.country_code, self.compact)
+
     @classmethod
     def from_components(cls, country_code: str, **values: str) -> BBAN:
         """Generate a BBAN from its national components.

--- a/tests/test_bban.py
+++ b/tests/test_bban.py
@@ -1,3 +1,6 @@
+import copy
+import pickle
+
 import pytest
 
 from schwifty.bban import BBAN
@@ -27,3 +30,19 @@ def test_random(country_code: str) -> None:
         bban.bank is None
         for bban in (BBAN.random(country_code, use_registry=False) for _ in range(n))
     )
+
+
+def test_pickle_roundtrip() -> None:
+    bban = BBAN("CH", "04835012345678009")
+    for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+        restored = pickle.loads(pickle.dumps(bban, protocol=proto))
+        assert restored == bban
+        assert restored.country_code == bban.country_code
+
+
+def test_deepcopy() -> None:
+    bban = BBAN("CH", "04835012345678009")
+    bban_copy = copy.deepcopy(bban)
+    assert bban_copy == bban
+    assert bban_copy.country_code == bban.country_code
+    assert id(bban_copy) != id(bban)


### PR DESCRIPTION
## Summary

`BBAN.__new__` has a two-argument signature `(cls, country_code, value)` — one argument more than the `Base` (str) class below it. Python's default pickle protocol reconstructs `str` subclasses by calling `__new__(cls, <str_value>)`, which passes the string value as `country_code` and leaves `value` missing. This raised `TypeError` every time a `BBAN` (or an `IBAN` whose `__dict__` contains a cached `BBAN`) was unpickled.

The same path was broken for `copy.deepcopy` because `Base.__deepcopy__` falls back to `self.__class__(str(self))` — the same one-argument call.

Fixes #262.

## Changes

- `schwifty/bban.py`: add `__getnewargs__` returning `(self.country_code, self.compact)` so pickle supplies both arguments to `__new__` on restore; add `__deepcopy__` that mirrors explicit two-argument construction.
- `tests/test_bban.py`: add `test_pickle_roundtrip` (all protocols) and `test_deepcopy`.
- `pyproject.toml`: suppress `S301` (pickle-safety lint) for the new test file.

## Verification

```
pytest tests/ -p no:anyio -q   # 397 passed (395 existing + 2 new)
ruff check schwifty/bban.py tests/test_bban.py
ruff format --check schwifty/bban.py tests/test_bban.py
```