### PR TITLE
Register ISO 7064 mod 97-10 checksum for BA, not BT (#264)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Changelog
 
 Versions follow `CalVer <http://www.calver.org/>`_ with the scheme ``YY.0M.Micro``.
 
+Unreleased
+----------
+Fixed
+~~~~~
+* Registered the ISO 7064 mod 97-10 national checksum algorithm for Bosnia and
+  Herzegovina (``BA``) instead of ``BT`` (Bhutan, which has no IBAN), so the
+  national checksum of ``BA`` IBANs is now validated (#264).
+
 `2026.03.0`_ - 2026/03/04
 -------------------------
 Added

--- a/schwifty/checksum/iso7064_mod97_10.py
+++ b/schwifty/checksum/iso7064_mod97_10.py
@@ -1,13 +1,13 @@
 from schwifty import checksum
 
 
-# Bosnia and Herzegovina (BT)
+# Bosnia and Herzegovina (BA)
 # Montenegro (ME)
 # North Macedonia (MK)
 # Portugal (PT)
 # Serbia (RS)
 # Slovenia (SI)
 # East Timor (TL)
-@checksum.register("BT", "ME", "MK", "PT", "RS", "SI", "TL")
+@checksum.register("BA", "ME", "MK", "PT", "RS", "SI", "TL")
 class DefaultAlgorithm(checksum.ISO7064_mod97_10):
     name = "default"

--- a/tests/test_bban.py
+++ b/tests/test_bban.py
@@ -12,6 +12,13 @@ def test_validate_national_checksum() -> None:
     with pytest.raises(InvalidBBANChecksum):
         BBAN("BE", "539007547035").validate_national_checksum()
 
+    # Bosnia and Herzegovina (BA) uses ISO 7064 mod 97-10; it was previously
+    # registered under the wrong country code "BT" (#264), so the national
+    # checksum was never validated.
+    assert BBAN("BA", "1290079401028494").validate_national_checksum() is True
+    with pytest.raises(InvalidBBANChecksum):
+        BBAN("BA", "1290079401028400").validate_national_checksum()
+
 
 @pytest.mark.parametrize("country_code", ["DE", "ES", "GB", "FR", "PL"])
 def test_random(country_code: str) -> None:


### PR DESCRIPTION
## Closes #264

In `schwifty/checksum/iso7064_mod97_10.py` the ISO 7064 mod 97-10 national checksum algorithm is registered for `BT`:

```python
# Bosnia and Herzegovina (BT)
...
@checksum.register("BT", "ME", "MK", "PT", "RS", "SI", "TL")
```

But the country code for **Bosnia and Herzegovina is `BA`** — `BT` is Bhutan, which is not part of the IBAN registry. So the algorithm was attached to a non-IBAN country, and **`BA` IBANs never had their national checksum validated**:

```python
>>> from schwifty import IBAN
# valid IBAN-level checksum, invalid national check digits
>>> IBAN("BA551290079401028400", validate_bban=True)   # accepted (bug)
```

### Fix
Register the algorithm for `BA` instead of `BT`.

Verified that Bosnia genuinely uses this algorithm: real `BA` IBANs (e.g. `BA391290079401028494`, `BA391011606058553319`) pass `validate_bban=True`, while a `BA` IBAN with corrupted national check digits is now correctly rejected with `InvalidBBANChecksum`. The other countries in the list (ME/MK/PT/RS/SI/TL) are unchanged.

### Tests
Added two assertions to `test_validate_national_checksum` (valid BA passes, corrupted BA raises). They fail on `main` and pass with the fix. Full suite stays green (395 tests). Added a CHANGELOG entry.