### PR TITLE
fix: validate IBAN characters over the full string, not just the prefix (#266)

### DIFF
--- a/schwifty/iban.py
+++ b/schwifty/iban.py
@@ -226,7 +226,11 @@ class IBAN(common.Base):
         return True
 
     def _validate_characters(self) -> None:
-        if not re.match(r"[A-Z]{2}\d{2}[A-Z]*", self):
+        # ``re.match`` only anchors the start, and ``[A-Z]*`` excludes the
+        # digits that appear in most BBANs, so invalid characters after the
+        # country/check-digit prefix slipped through. ``fullmatch`` over the
+        # alphanumeric BBAN catches them.
+        if not re.fullmatch(r"[A-Z]{2}\d{2}[A-Z0-9]+", self):
             raise exceptions.InvalidStructure(f"Invalid characters in IBAN {self!s}")
 
     def _validate_length(self) -> None:

--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -6,6 +6,7 @@ import pytest
 from pycountry import countries  # type: ignore
 
 from schwifty import IBAN
+from schwifty.exceptions import InvalidStructure
 from schwifty.exceptions import SchwiftyException
 from schwifty.iban import convert_bban_spec_to_regex
 
@@ -202,6 +203,15 @@ def test_parse_iban_allow_invalid(value: str) -> None:
 def test_invalid_iban(value: str) -> None:
     with pytest.raises(SchwiftyException):
         IBAN(value)
+
+
+def test_invalid_characters_in_bban_are_rejected() -> None:
+    # Regression for #266: ``_validate_characters`` used ``re.match`` (anchored
+    # only at the start) with ``[A-Z]*``, so an invalid character inside the
+    # BBAN slipped past character validation. ``fullmatch`` over the
+    # alphanumeric BBAN now catches it.
+    with pytest.raises(InvalidStructure):
+        IBAN("GB82WEST1234£698765432")  # '£' where a digit is expected
 
 
 def test_iban_properties_de() -> None:


### PR DESCRIPTION
## Problem

`_validate_characters` (in `schwifty/iban.py`) was:

```python
if not re.match(r"[A-Z]{2}\d{2}[A-Z]*", self):
    raise exceptions.InvalidStructure(...)
```

Two issues (see #266):

1. **`re.match` only anchors the start.** It matches a *prefix*, so any invalid character *after* the country code + check digits (i.e. inside the BBAN) is never seen by character validation.
2. **`[A-Z]*` excludes digits**, which appear in almost every BBAN — so the pattern never described a real IBAN body in the first place; it only ever "passed" because `re.match` stopped at the first digit.

Invalid characters were only caught incidentally by later validators (`_validate_format`), so the dedicated character check wasn't doing its job.

## Fix

Use `re.fullmatch` over an alphanumeric BBAN class:

```python
if not re.fullmatch(r"[A-Z]{2}\d{2}[A-Z0-9]+", self):
    raise exceptions.InvalidStructure(...)
```

## Verification

- Generated a registry-valid IBAN for **all 126 countries** — none regressed (every valid IBAN still passes character validation).
- An invalid character inside the BBAN is now rejected by `InvalidStructure` directly.
- Full `tests/test_iban.py` suite green (244 passed), including a new regression test `test_invalid_characters_in_bban_are_rejected`.

Fixes #266

---
*AI-assisted, human-reviewed — I'm an AI engineer; I find, fix, and test with AI, then review and verify before opening under my name.*
