### PR TITLE
Fix BIC structure validation to check the full string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ Versions follow `CalVer <http://www.calver.org/>`_ with the scheme ``YY.0M.Micro
 
 Unreleased
 ----------
+Fixed
+~~~~~
+* Validate the whole BIC string when checking its structure. Previously the
+  check was only anchored at the start, so an 11-character BIC with
+  non-alphanumeric characters in the branch code (e.g. ``GENODEM1@#%``) was
+  accepted and even exposed the garbage through ``BIC.branch_code``
+  `@gaoflow <https://github.com/gaoflow>`_.
 
 `2026.07.0`_ - 2026/07/02
 -------------------------

--- a/schwifty/bic.py
+++ b/schwifty/bic.py
@@ -281,7 +281,7 @@ class BIC(common.Base):
 
     def _validate_structure(self, enforce_swift_compliance: bool = False) -> None:
         regex = _bic_swift_re if enforce_swift_compliance else _bic_iso9362_re
-        if not regex.match(str(self)):
+        if not regex.fullmatch(str(self)):
             raise exceptions.InvalidStructure(f"Invalid structure '{self!s}'")
 
     def _validate_country_code(self) -> None:

--- a/tests/test_bic.py
+++ b/tests/test_bic.py
@@ -100,12 +100,45 @@ def test_enforce_swift_compliance() -> None:
         ("AAAA", exceptions.InvalidLength),
         ("AAAADEM1GLSX", exceptions.InvalidLength),
         ("GENOD1M1GLS", exceptions.InvalidStructure),
+        ("GENODEM1@#%", exceptions.InvalidStructure),
         ("GENOXXM1GLS", exceptions.InvalidCountryCode),
     ],
 )
 def test_invalid_bic(code: str, exc: type[Exception]) -> None:
     with pytest.raises(exc):
         BIC(code)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "GENODEM1@#%",  # symbols in the branch code
+        "GENODEM1G-S",  # dash in the branch code
+        "GENODEM1GL*",  # star in the branch code
+        "MARKDEF1$$$",  # dollar signs in the branch code
+        "GENODEM1..X",  # dots in the branch code
+    ],
+)
+def test_invalid_bic_branch_code_characters(code: str) -> None:
+    # An 11-character BIC whose branch code (positions 9-11) contains
+    # non-alphanumeric characters must be rejected. The structure check only
+    # anchored the start of the string, so with the branch-code group being
+    # optional the trailing garbage slipped through and was even exposed via
+    # ``BIC.branch_code``.
+    with pytest.raises(exceptions.InvalidStructure):
+        BIC(code)
+    with pytest.raises(exceptions.InvalidStructure):
+        BIC(code, enforce_swift_compliance=True)
+
+    invalid = BIC(code, allow_invalid=True)
+    assert not invalid.is_valid
+
+
+def test_bic_structure_is_validated_over_full_string() -> None:
+    # Regression guard for the full-string structure validation: genuinely valid
+    # 8- and 11-character BICs must keep validating after the fix.
+    for code in ("GENODEM1", "GENODEM1GLS", "MARKDEF1100", "1234DEWWXXX"):
+        assert BIC(code).validate()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Problem

`BIC._validate_structure` checks the code with `regex.match(...)`. Because
`re.match` only anchors the *start* of the string and the branch-code group in
the ISO 9362 / SWIFT patterns is optional, an 11-character BIC whose branch code
(positions 9–11) contains non-alphanumeric characters is accepted as valid, and
the garbage is even surfaced through `BIC.branch_code`:

```python
>>> from schwifty import BIC
>>> bic = BIC("GENODEM1@#%")      # no error
>>> bic.is_valid
True
>>> bic.branch_code
'@#%'
```

The same class of bug was recently fixed for IBAN in #293 ("validate IBAN
characters over the full string, not just the start"); this is the BIC sibling.

### Fix

Use `re.fullmatch` so the trailing branch-code characters are validated too.
Genuine 8- and 11-character BICs continue to validate.

### Tests

- Adds `GENODEM1@#%` to the `test_invalid_bic` structure cases.
- Adds `test_invalid_bic_branch_code_characters` covering several kinds of
  garbage branch codes (symbols, dash, star, dollar, dots), asserting both the
  default and `enforce_swift_compliance=True` paths raise `InvalidStructure`
  and that `allow_invalid=True` reports `is_valid == False`.
- Adds `test_bic_structure_is_validated_over_full_string` as a regression guard
  that valid 8/11-char BICs still validate after the change.

`pytest tests/test_bic.py` → 92 passed. `ruff check` / `ruff format --check` clean.
