### PR TITLE
Generate random BBANs that satisfy the national checksum (#219)

### DIFF
--- a/schwifty/bban.py
+++ b/schwifty/bban.py
@@ -214,7 +214,12 @@ class BBAN(common.Base):
             return cls(country_code, rstr.xeger(spec["regex"]).upper())
 
         ranges = _get_position_ranges(spec)
-        for _ in range(100):
+        # A random account code only satisfies a bank-specific national checksum with
+        # low probability (some German methods hit roughly 1-in-50), so allow enough
+        # attempts that a valid BBAN is found in practice. Countries without a checksum
+        # succeed on the first iteration, so the higher bound only affects the retry
+        # path.
+        for _ in range(2000):
             bban = rstr.xeger(spec["regex"]).upper()
             components: dict[Component, str] = {}
             for key, range_ in ranges.items():
@@ -238,13 +243,18 @@ class BBAN(common.Base):
                 components[key] = value[: ranges[key].length]
 
             try:
-                return cls.from_components(
+                bban = cls.from_components(
                     country_code, **{key.value: value for key, value in components.items()}
                 )
+                # A randomly generated account code will usually not satisfy the
+                # bank-specific national checksum (e.g. the many German methods), so
+                # reject and retry until the generated BBAN validates against its own
+                # checksum algorithm. Banks without a known algorithm validate trivially.
+                bban.validate_national_checksum()
             except exceptions.SchwiftyException:
-                pass
-        else:
-            raise exceptions.GenerateRandomOverflowError
+                continue
+            return bban
+        raise exceptions.GenerateRandomOverflowError
 
     def validate_national_checksum(self) -> bool:
         """bool: Validate the national checksum digits.

--- a/tests/test_bban.py
+++ b/tests/test_bban.py
@@ -4,6 +4,7 @@ import pickle
 import pytest
 
 from schwifty.bban import BBAN
+from schwifty.exceptions import GenerateRandomOverflowError
 from schwifty.exceptions import InvalidBBANChecksum
 
 
@@ -37,6 +38,18 @@ def test_random(country_code: str) -> None:
         bban.bank is None
         for bban in (BBAN.random(country_code, use_registry=False) for _ in range(n))
     )
+
+
+def test_random_national_checksum_overflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When no generated candidate ever satisfies the national checksum, random()
+    # exhausts its retries and raises GenerateRandomOverflowError rather than
+    # returning a BBAN with an invalid checksum.
+    def always_invalid(self: BBAN) -> bool:
+        raise InvalidBBANChecksum
+
+    monkeypatch.setattr(BBAN, "validate_national_checksum", always_invalid)
+    with pytest.raises(GenerateRandomOverflowError):
+        BBAN.random("DE")
 
 
 def test_pickle_roundtrip() -> None:

--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -422,6 +422,16 @@ def test_random_iban() -> None:
         assert isinstance(iban, IBAN)
 
 
+@pytest.mark.parametrize("country_code", ["DE", "IT", "BE"])
+def test_random_passes_national_checksum(country_code: str) -> None:
+    # Regression test for #219: randomly generated IBANs for countries with a
+    # bank-specific national checksum (e.g. the German methods) must satisfy that
+    # checksum, i.e. ``validate(validate_bban=True)`` must not raise.
+    for _ in range(50):
+        iban = IBAN.random(country_code=country_code)
+        assert iban.validate(validate_bban=True) is True
+
+
 def test_random_special_cases() -> None:
     iban = IBAN.random(country_code="MU")
     assert iban.endswith("000MUR")


### PR DESCRIPTION
Fixes #219.

`IBAN.random()` / `BBAN.random()` generate a random account code but never check it against the bank-specific national checksum, so for countries whose checksum is embedded in the account number the result is usually invalid. On current `main`, roughly 3 out of 4 random German IBANs fail their own checksum:

```python
import schwifty
fails = 0
for _ in range(200):
    iban = schwifty.IBAN.random(country_code="DE")
    try:
        iban.validate(validate_bban=True)
    except schwifty.exceptions.InvalidBBANChecksum:
        fails += 1
print(fails)   # ~146 on main, 0 with this change
```

`compute_national_checksum()` only ever applies the `"<country>:default"` algorithm, whereas `validate_national_checksum()` selects the *bank-specific* algorithm (e.g. the German method `63`), so the generated digits and the validated digits disagree. Computing a valid embedded check digit directly would mean reimplementing each of the ~150 German methods' insertion logic — the "tricky" part noted in the issue.

Instead this reuses the validation that already exists: `BBAN.random()` now rejects a candidate that fails `validate_national_checksum()` and retries. Because a random account satisfies some German methods only ~1 in 50 of the time, the attempt bound is raised so a valid BBAN is reliably found. Countries without a national checksum validate trivially and still return on the first attempt, so their behaviour and cost are unchanged.

Verified: 0 invalid / 0 overflow across 1000 random IBANs each for DE, IT, BE, GB, FR, ES and for fully-random `IBAN.random()`. Added a regression test (`test_random_passes_national_checksum`) for DE/IT/BE. Full suite passes (385) and `ruff` is clean.

If you'd rather compute the check digit directly for a subset of methods (faster, no retries), happy to look into that separately.

*Disclosure: this change was written with AI assistance and reviewed/tested before submitting.*
