### PR TITLE
Fix German checksum method 08 threshold (60000, not 6000)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Fixed
   non-alphanumeric characters in the branch code (e.g. ``GENODEM1@#%``) was
   accepted and even exposed the garbage through ``BIC.branch_code``
   `@gaoflow <https://github.com/gaoflow>`_.
+* Fixed the German checksum method ``08`` threshold. Per the Bundesbank
+  specification the check digit is only applied from account number ``60000``
+  upward, but the threshold was set to ``6000``. Accounts in the
+  ``[6000, 60000)`` range for banks using method ``08`` (e.g. NRW.BANK,
+  Helaba) were wrongly rejected.
+  `@chuenchen309 <https://github.com/chuenchen309>`_.
 
 
 `2026.07.1`_ - 2026/07/06

--- a/schwifty/checksum/germany.py
+++ b/schwifty/checksum/germany.py
@@ -173,7 +173,7 @@ class Algorithm07(Algorithm02):
 @register
 class Algorithm08(Algorithm00):
     name = "08"
-    min_account_code = 6000
+    min_account_code = 60000
 
     @override
     def compute(self, components: list[str]) -> str:

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -66,6 +66,10 @@ from schwifty.checksum import algorithms
         ("0847321750", "DE:99"),
         ("0396000000", "DE:99"),
         ("0499999999", "DE:99"),
+        # Method 08 applies no check digit below account number 60000, so an
+        # account in [6000, 60000) is valid regardless of its check digit.
+        ("0000006000", "DE:08"),
+        ("0000059999", "DE:08"),
     ],
 )
 def test_german_checksum_success(account_code: str, algorithm_name: str) -> None:
@@ -85,6 +89,9 @@ def test_german_checksum_success(account_code: str, algorithm_name: str) -> None
         ("8840062000", "DE:91"),
         ("8840010000", "DE:91"),
         ("8840057000", "DE:91"),
+        # From account number 60000 upward method 08 does apply the check, so a
+        # wrong check digit must still be rejected.
+        ("0000060000", "DE:08"),
     ],
 )
 def test_german_checksum_failure(account_code: str, algorithm_name: str) -> None:


### PR DESCRIPTION
## Summary

Bundesbank check-digit method `08` applies the check digit only from account
number `60000` upward — below that, no check digit is applied. From the
specification PDF linked in `germany.py`'s own module docstring:

> **08** Modulus 10, Gewichtung 2, 1, 2, 1, 2, 1, 2, 1, 2 (modifiziert)
> Die Berechnung erfolgt wie bei Verfahren 00, **jedoch erst ab der Kontonummer 60 000**.

The threshold in `Algorithm08` was `6000` (a dropped zero), so accounts in the
`[6000, 60000)` range were run through the method-00 check and rejected whenever
their check digit didn't happen to satisfy it. Five real primary banks use
method `08` — NRW.BANK (`30022000`, `40022000`) and Helaba (`30050000`,
`40050000`, `44050000`) — so `IBAN(..., validate_bban=True)` wrongly rejected
otherwise-valid German IBANs for those banks, e.g.:

```python
>>> IBAN("DE66300220000000006000", validate_bban=True)   # account 6000
InvalidBBANChecksum        # before: rejected;  after: accepted (spec: no check < 60000)
```

## Fix

`schwifty/checksum/germany.py`: `min_account_code = 6000` → `60000`.

Accounts `< 60000` now validate without a check digit (as the spec requires);
accounts `>= 60000` are still checked, so a genuinely wrong check digit is still
rejected.

## Tests

Added method-`08` cases to `test_checksum.py`: two in-range accounts (`6000`,
`59999`) to the success set — they fail on `main` and pass with the fix — plus a
`>= 60000` account in the failure set to guard the boundary. Full test suite:
409 passed.

---

Disclosure: this PR was authored by an AI coding agent (Claude Code) running on
this account — it found the discrepancy against the Bundesbank specification,
reproduced it, wrote the fix and the tests, and wrote this description. The
account holder reviews every change and is accountable for it, and the
verification above is real and re-runnable from the diff. Happy to close it if
it's not the kind of contribution you want.
