### PR TITLE
refactor(iban): drop redundant mod-97 check in checksum validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Changelog
 
 Versions follow `CalVer <http://www.calver.org/>`_ with the scheme ``YY.0M.Micro``.
 
+Unreleased
+----------
+Changed
+~~~~~~~
+* Simplified the IBAN checksum validation. The redundant ``self.numeric % 97 == 1`` test has
+  been dropped in favour of the stricter canonical ``ISO7064_mod97_10`` comparison, which it
+  always implied. Behaviour is unchanged.
+
 `2026.07.3`_ - 2026/07/23
 -------------------------
 Changed

--- a/schwifty/iban.py
+++ b/schwifty/iban.py
@@ -243,10 +243,13 @@ class IBAN(common.Base):
             )
 
     def _validate_iban_checksum(self) -> None:
+        # Validating against the canonically computed check digits is stricter than a bare
+        # ``self.numeric % 97 == 1`` test: the ISO 7064 mod-97-10 algorithm only ever yields
+        # check digits in the range 02..98, whereas the raw mod-97 test additionally accepts the
+        # aliases 00, 01 and 99 (which no genuine IBAN carries). A passing ``validate`` always
+        # implies ``self.numeric % 97 == 1``, so the latter check is redundant.
         checksum_algo = ISO7064_mod97_10()
-        if self.numeric % 97 != 1 or not checksum_algo.validate(
-            [self.bban, self.country_code], self.checksum_digits
-        ):
+        if not checksum_algo.validate([self.bban, self.country_code], self.checksum_digits):
             raise exceptions.InvalidChecksumDigits("Invalid checksum digits")
 
     @property


### PR DESCRIPTION
## Summary

Resolves the question raised in #243 by simplifying `IBAN._validate_iban_checksum()`.

The condition combined two checks with `or`:

```python
if self.numeric % 97 != 1 or not checksum_algo.validate(
    [self.bban, self.country_code], self.checksum_digits
):
    raise exceptions.InvalidChecksumDigits("Invalid checksum digits")
```

As the reporter suspected, the two are closely related — but they are **not** identical:

- `self.numeric % 97 == 1` is the raw ISO 13616 mod-97 test.
- `checksum_algo.validate(...)` compares against the *canonically computed* ISO 7064 mod-97-10 check digits, which only ever fall in the range **02–98**.

The canonical comparison is **strictly stronger**: it additionally rejects the check-digit aliases **00, 01 and 99**, which satisfy `mod 97 == 1` but which no genuine IBAN carries (e.g. canonical `02` ↔ alias `99`, `97` ↔ `00`, `98` ↔ `01`).

Because a passing `validate()` **always implies** `self.numeric % 97 == 1`, the `or`-combined modulo test is redundant. Dropping it leaves behaviour unchanged while keeping the tighter of the two checks.

## Changes

- Remove the redundant `self.numeric % 97 != 1` term; keep only `checksum_algo.validate(...)`.
- Add an explanatory comment covering why the canonical check subsumes the modulo test.
- Changelog entry under *Unreleased*.

The public `IBAN.numeric` property is retained.

## Testing

- `poe test` — all 421 tests pass.

Closes #243