### PR TITLE
Resolve bank data for BICs that carry a branch code

### DIFF
--- a/schwifty/bic.py
+++ b/schwifty/bic.py
@@ -363,6 +363,12 @@ class BIC(common.Base):
 
     def _lookup_values(self, key: str) -> list[str]:
         entries = registry.get_banks_by_bic(str(self))
+        if not entries and self.branch_code:
+            # An 11-character BIC denotes a branch of the institution that the
+            # first 8 characters identify. Not every national registry lists
+            # entries per branch, so fall back to the institution's BIC when
+            # the branch-specific lookup comes up empty.
+            entries = registry.get_banks_by_bic(str(self)[:8])
         return sorted({getattr(entry, key) for entry in entries if getattr(entry, key)})
 
     @property

--- a/tests/test_bic.py
+++ b/tests/test_bic.py
@@ -74,6 +74,27 @@ def test_unknown_bic_properties() -> None:
     assert bic.type == "default"
 
 
+def test_bic_with_branch_code_falls_back_to_institution() -> None:
+    # Some registries only list the 8-character institution BIC. An extended
+    # 11-character BIC denotes a branch of that same institution, so it should
+    # still resolve to the institution's data rather than returning nothing.
+    institution = BIC("BSABESBB")
+    assert institution.domestic_bank_codes
+    for extended in ("BSABESBBXXX", "BSABESBB001"):
+        bic = BIC(extended)
+        assert bic.branch_code
+        assert bic.domestic_bank_codes == institution.domestic_bank_codes
+        assert bic.bank_names == institution.bank_names
+        assert bic.bank_short_names == institution.bank_short_names
+
+
+def test_bic_prefers_branch_specific_registry_entry() -> None:
+    # Where the registry does hold branch-specific entries, those must still
+    # win over the institution-level fallback.
+    assert BIC("MARKDEF1100").domestic_bank_codes == ["10000000"]
+    assert BIC("GENODEM1GLS").domestic_bank_codes == ["43060967", "43060988"]
+
+
 @pytest.mark.parametrize(
     ("code", "type"),
     [


### PR DESCRIPTION
Closes #112.

### Problem
`BIC.domestic_bank_codes` (and `bank_names` / `bank_short_names`) returned nothing for an extended 11-character BIC, even when the 8-character form resolved fine:

```python
>>> BIC("BSABESBB").domestic_bank_codes
['0008', '0013', '0042', ...]   # 20 codes
>>> BIC("BSABESBBXXX").domestic_bank_codes
[]
>>> BIC("BSABESBB001").domestic_bank_codes
[]
```

All three denote the same institution, so the empty results are surprising.

### Cause
`_lookup_values` matches the registry on the **full** BIC string, so an 11-character BIC only resolves when the registry happens to contain an entry for that exact branch. The registries aren't consistent about this:

| lookup | entries |
|---|---|
| `BSABESBB` (ES, institution) | 20 |
| `BSABESBBXXX` | 0 |
| `MARKDEF1100` (DE, branch) | 1 |
| `MARKDEF1` | 0 |

Spain lists the institution BIC; Germany lists branch-specific ones. So whether an 11-character BIC works depends on which country's data you happen to hit.

### Fix
When a branch-specific lookup finds nothing, fall back to the 8-character institution BIC. It only triggers on an otherwise-empty result, so:

- branch-specific entries (`MARKDEF1100`, `GENODEM1GLS`) still take precedence — unchanged;
- BICs absent from the registry entirely (`ABNAJPJTXXX`) still return `[]` — unchanged;
- `domestic_bank_codes`, `bank_names` and `bank_short_names` are fixed together, since they share `_lookup_values`.

### Tests
Added `test_bic_with_branch_code_falls_back_to_institution` (fails on `main`, passes here) and `test_bic_prefers_branch_specific_registry_entry` (guards that exact branch entries still win). Full suite: 406 passed; `ruff check` / `ruff format --check` clean.

### Two things I deliberately left alone
- `BIC("BSABESBBXXX").exists` still reports `False`, since that exact BIC genuinely isn't in the registry. Happy to align it if you'd rather `exists` follow the same fallback.
- The reverse asymmetry (`MARKDEF1` → no entries although branch entries exist) is arguably also worth smoothing, but aggregating all branches under an institution BIC is a bigger behavioural change, so I kept this PR to the reported case.
