### PR TITLE
Add missing EMIs and banks to the bank registries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Versions follow `CalVer <http://www.calver.org/>`_ with the scheme ``YY.0M.Micro
 
 Unreleased
 ----------
+Added
+~~~~~
+* Added e-money institutions and banks that were missing from the bank registries: OpenPayd
+  (MT — first Maltese registry), ClearBank and Bilderlings Pay (GB), Score and Secure Payment
+  and Deblock (FR), bunq, Pecunia Cards and Financière des Paiements Électroniques (ES),
+  Unlimit (CY), MyFin (BG), Revolut Bank (PT), Enpara Bank (TR), United Bank and Allied Bank
+  (PK — first Pakistani registry), and the BIC for PrivatBank (UA).
+
 Changed
 ~~~~~~~
 * Simplified the IBAN checksum validation. The redundant ``self.numeric % 97 == 1`` test has

--- a/schwifty/bank_registry/manual_bg.json
+++ b/schwifty/bank_registry/manual_bg.json
@@ -183,12 +183,20 @@
     "bic": "CEDPBGSF",
     "primary": true
   },
-    {
+  {
     "country_code": "BG",
     "bank_code": "INTF",
     "short_name": "ICARD AD",
     "name": "ICARD AD",
     "bic": "INTFBGSF",
+    "primary": true
+  },
+  {
+    "country_code": "BG",
+    "bank_code": "MYFN",
+    "short_name": "MYFIN EAD",
+    "name": "MYFIN EAD",
+    "bic": "MYFNBGSF",
     "primary": true
   }
 ]

--- a/schwifty/bank_registry/manual_cy.json
+++ b/schwifty/bank_registry/manual_cy.json
@@ -374,5 +374,13 @@
     "name": "ANCORIA BANK LTD, LIMASSOL BANKING CENTRE",
     "primary": true,
     "short_name": "ANCORIA BANK LTD"
+  },
+  {
+    "bank_code": "902",
+    "bic": "CARDCY2L",
+    "country_code": "CY",
+    "name": "UNLIMIT EU LTD",
+    "primary": true,
+    "short_name": "UNLIMIT EU LTD"
   }
 ]

--- a/schwifty/bank_registry/manual_es.json
+++ b/schwifty/bank_registry/manual_es.json
@@ -62,5 +62,29 @@
     "bic": "MODRESB2",
     "name": "MODULR FINANCE B.V., SPAIN BRANCH",
     "short_name": "MODULR FINANCE"
+  },
+  {
+    "country_code": "ES",
+    "primary": true,
+    "bank_code": "1576",
+    "bic": "BUNQESM2",
+    "name": "BUNQ B.V., SUCURSAL EN ESPANA",
+    "short_name": "BUNQ"
+  },
+  {
+    "country_code": "ES",
+    "primary": true,
+    "bank_code": "6707",
+    "bic": "PCRDESMM",
+    "name": "PECUNIA CARDS E.D.E., S.L.U.",
+    "short_name": "PECUNPAY"
+  },
+  {
+    "country_code": "ES",
+    "primary": true,
+    "bank_code": "6893",
+    "bic": "FPESESM2",
+    "name": "FINANCIERE DES PAIEMENTS ELECTRONIQUES, SUCURSAL EN ESPANA",
+    "short_name": "NICKEL"
   }
 ]

--- a/schwifty/bank_registry/manual_fr.json
+++ b/schwifty/bank_registry/manual_fr.json
@@ -2630,5 +2630,21 @@
     "name": "BANQUE MICHEL INCHAUSPE",
     "short_name": "BAMI",
     "primary": true
+  },
+  {
+    "country_code": "FR",
+    "bic": "SCSYFRP2",
+    "bank_code": "17238",
+    "name": "SCORE AND SECURE PAYMENT",
+    "short_name": "SCORE AND SECURE PAYMENT",
+    "primary": true
+  },
+  {
+    "country_code": "FR",
+    "bic": "DBLKFR22",
+    "bank_code": "17748",
+    "name": "DEBLOCK SAS",
+    "short_name": "DEBLOCK",
+    "primary": true
   }
 ]

--- a/schwifty/bank_registry/manual_gb.json
+++ b/schwifty/bank_registry/manual_gb.json
@@ -382,5 +382,21 @@
     "name": "NORTHERN BANK LIMITED T/A DANSKE BA",
     "short_name": "NORTHERN BANK LIMITED T/A DANSKE BA",
     "primary": true
+  },
+  {
+    "country_code": "GB",
+    "bic": "CLRBGB22",
+    "bank_code": "CLRB",
+    "name": "CLEARBANK LIMITED",
+    "short_name": "CLEARBANK",
+    "primary": true
+  },
+  {
+    "country_code": "GB",
+    "bic": "BIYSGB2L",
+    "bank_code": "BIYS",
+    "name": "BILDERLINGS PAY LIMITED",
+    "short_name": "BILDERLINGS PAY",
+    "primary": true
   }
 ]

--- a/schwifty/bank_registry/manual_mt.json
+++ b/schwifty/bank_registry/manual_mt.json
@@ -1,0 +1,10 @@
+[
+  {
+    "country_code": "MT",
+    "bic": "CFTEMTM1",
+    "bank_code": "CFTE",
+    "name": "OpenPayd Financial Services Malta Ltd",
+    "short_name": "OpenPayd",
+    "primary": true
+  }
+]

--- a/schwifty/bank_registry/manual_pk.json
+++ b/schwifty/bank_registry/manual_pk.json
@@ -1,0 +1,18 @@
+[
+  {
+    "country_code": "PK",
+    "bic": "UNILPKKA",
+    "bank_code": "UNIL",
+    "name": "United Bank Limited",
+    "short_name": "UBL",
+    "primary": true
+  },
+  {
+    "country_code": "PK",
+    "bic": "ABPAPKKA",
+    "bank_code": "ABPA",
+    "name": "Allied Bank Limited",
+    "short_name": "Allied Bank",
+    "primary": true
+  }
+]

--- a/schwifty/bank_registry/manual_pt.json
+++ b/schwifty/bank_registry/manual_pt.json
@@ -670,5 +670,13 @@
     "name": "SANTANDER TOTTA, SGPS, S.A.",
     "short_name": "SANTANDER TOTTA",
     "primary": true
+  },
+  {
+    "country_code": "PT",
+    "bank_code": "3560",
+    "bic": "REVOPTP2",
+    "name": "REVOLUT BANK UAB, SUCURSAL EM PORTUGAL",
+    "short_name": "REVOLUT BANK",
+    "primary": true
   }
 ]

--- a/schwifty/bank_registry/manual_tr.json
+++ b/schwifty/bank_registry/manual_tr.json
@@ -406,5 +406,13 @@
     "bank_code": "00121",
     "bic": "SCBLTRIS",
     "primary": true
+  },
+  {
+    "country_code": "TR",
+    "name": "Enpara Bank A.\u015e.",
+    "short_name": "Enpara Bank A.\u015e.",
+    "bank_code": "00157",
+    "bic": "ENASTRIS",
+    "primary": true
   }
 ]

--- a/schwifty/bank_registry/manual_ua.json
+++ b/schwifty/bank_registry/manual_ua.json
@@ -1,0 +1,10 @@
+[
+  {
+    "country_code": "UA",
+    "bic": "PBANUA2X",
+    "bank_code": "305299",
+    "name": "JSC CB PrivatBank",
+    "short_name": "PrivatBank",
+    "primary": true
+  }
+]


### PR DESCRIPTION
IBANs of several e-money institutions resolve no bank and no BIC — the national bank lists behind the generated registries omit EMIs. These codes were the bulk of our unresolved IBANs when resolving BICs at scale.

**Before:** `IBAN('MT25CFTE...').bic` → `None`; `BIC.from_bank_code('UA', '305299')` raises for Ukraine's largest bank (its generated entries carry an empty `bic`).
**After:** every code below resolves. `manual_mt.json`/`manual_pk.json` are first entries for their countries; `manual_ua.json` adds only PrivatBank's BIC — `bank_name` still resolves to the NBU-sourced entry, since `generated_` sorts first.

Each entry verified against two independent sources:

| Code | BIC | Institution | Sources |
|---|---|---|---|
| MT CFTE | CFTEMTM1 | OpenPayd | [1](https://www.swiftref.com/en/ibanvalidation) [2](https://www.ibantest.com/en/swift-codes/CFTEMTM1XXX) |
| GB CLRB | CLRBGB22 | ClearBank | [1](https://www.theswiftcodes.com/united-kingdom/clrbgb22/) [2](https://wise.com/gb/swift-codes/CLRBGB22XXX) |
| GB BIYS | BIYSGB2L | Bilderlings Pay | [1](https://www.theswiftcodes.com/united-kingdom/biysgb2l/) [2](https://bank.codes/swift-code/united-kingdom/biysgb2l/) |
| FR 17238 | SCSYFRP2 | Score and Secure Payment | [1](https://sspayment.com/en/legal-notices/) [2](https://www.theswiftcodes.com/france/scsyfrp2/) |
| FR 17748 | DBLKFR22 | Deblock | [1](https://thebanks.eu/emis/deblock-355392) [2](https://www.theswiftcodes.com/france/dblkfr22/) |
| CY 902 | CARDCY2L | Unlimit EU | [1](https://www.centralbank.cy/images/media/redirectfile/IBAN/CIs_and_EMIs_BICs_updated_April_2025.xlsx) [2](https://thebanks.eu/emis/unlimint-eu-354681) |
| ES 1576 | BUNQESM2 | bunq (ES branch) | [1](https://risklab.es/banco-1576-bunq/) [2](https://www.theswiftcodes.com/spain/bunqesm2/) |
| ES 6707 | PCRDESMM | Pecunia Cards | [1](https://www.pecunpay.es/sac.html) [2](https://www.theswiftcodes.com/spain/pcrdesmm/) |
| ES 6893 | FPESESM2 | FPE (Nickel) | [1](https://nickel.eu/sites/default/files/General-Terms-and-Conditions_ES_es.pdf) [2](https://www.theswiftcodes.com/spain/fpesesm2/) |
| BG MYFN | MYFNBGSF | MyFin | [1](https://www.theswiftcodes.com/bulgaria/myfnbgsf/) [2](https://www.xe.com/swift-codes/MYFNBGSFXXX/) |
| PT 3560 | REVOPTP2 | Revolut Bank (PT branch) | [1](https://www.bportugal.pt/en/entidadeautorizada/revolut-bank-uab-sucursal-em-portugal) [2](https://www.theswiftcodes.com/portugal/revoptp2/) |
| TR 00157 | ENASTRIS | Enpara Bank | [1](https://www.tcmb.gov.tr/wps/wcm/connect/9fa62a85-5b6d-46c5-9b01-eb461d43723d/TCMB+%C3%96deme+Sistemleri+Kat%C4%B1l%C4%B1mc%C4%B1lar%C4%B1+%282024%29+%28internet+sayfas%C4%B1na+y%C3%BCklenen%29.pdf?MOD=AJPERES) [2](https://wise.com/us/swift-codes/ENASTRISXXX) |
| PK UNIL | UNILPKKA | United Bank | [1](https://www.theswiftcodes.com/pakistan/unilpkka/) [2](https://wise.com/us/swift-codes/UNILPKKAXXX) |
| PK ABPA | ABPAPKKA | Allied Bank | [1](https://www.theswiftcodes.com/pakistan/abpapkka/) [2](https://www.xe.com/swift-codes/ABPAPKKAXXX/) |
| UA 305299 | PBANUA2X | PrivatBank | [1](https://www.iban.com/banks/privatbank) [2](https://bankchart.com.ua/spravochniki/rekvizity_bankov/id/1) |

Directories disagree on OpenPayd (`CFTEMTM1` vs `CFTEMTM3`, both theirs); SWIFT's IBAN Plus lookup returns `CFTEMTM1XXX`, used here. Changelog entry included.