### PR TITLE
refactor: simplify internal helpers, caching, and validation across c…

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -95,4 +95,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: hynek/build-and-inspect-python-package@@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1
+      - uses: hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -95,4 +95,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: hynek/build-and-inspect-python-package@v3
+      - uses: hynek/build-and-inspect-python-package@@2abe76da66d0a6a4a227101f9348ee855797cfa5 # v3.0.1

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -95,4 +95,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: hynek/build-and-inspect-python-package@v2
+      - uses: hynek/build-and-inspect-python-package@v3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Added
 
 Changed
 ~~~~~~~
+* Simplified internal registry caching, character lookups, checksum helpers, and validation routines
+  for improved efficiency and cleaner code structure while preserving exact behavior.
 * Simplified the IBAN checksum validation. The redundant ``self.numeric % 97 == 1`` test has
   been dropped in favour of the stricter canonical ``ISO7064_mod97_10`` comparison, which it
   always implied. Behaviour is unchanged.

--- a/schwifty/bban.py
+++ b/schwifty/bban.py
@@ -275,15 +275,18 @@ class BBAN(common.Base):
         return _get_bban_spec(self.country_code)
 
     @property
+    def _bank_lookup_key(self) -> str:
+        lookup_by = self.spec.bic_lookup_components or [Component.BANK_CODE]
+        return "".join(self._get_component(component) for component in lookup_by)
+
+    @property
     def bic(self) -> BIC | None:
         """BIC or None: The BIC associated to the BBAN's bank-code.
 
         If the bank code is not available in schwifty's registry ``None`` is returned.
         """
-        lookup_by = self.spec.bic_lookup_components or [Component.BANK_CODE]
-        key = "".join(self._get_component(component) for component in lookup_by)
         try:
-            return BIC.from_bank_code(self.country_code, key)
+            return BIC.from_bank_code(self.country_code, self._bank_lookup_key)
         except exceptions.SchwiftyException:
             return None
 
@@ -342,9 +345,7 @@ class BBAN(common.Base):
     @property
     def bank(self) -> Bank | None:
         """Bank | None: The information of bank related to this BBANs bank code."""
-        lookup_by = self.spec.bic_lookup_components or [Component.BANK_CODE]
-        key = "".join(self._get_component(component) for component in lookup_by)
-        bank_entry = registry.get_banks_by_code(self.country_code, key)
+        bank_entry = registry.get_banks_by_code(self.country_code, self._bank_lookup_key)
         if not bank_entry:
             return None
         return bank_entry[0]

--- a/schwifty/bic.py
+++ b/schwifty/bic.py
@@ -162,16 +162,17 @@ class BIC(common.Base):
             * United Arab Emirates
             * United Kingdom
         """
-        banks = sorted(
-            registry.get_banks_by_code(country_code, bank_code),
-            key=lambda b: b.primary,
-            reverse=True,
-        )
+        banks = registry.get_banks_by_code(country_code, bank_code)
         if not banks:
             raise exceptions.InvalidBankCode(
                 f"Unknown bank code {bank_code!r} for country {country_code!r}"
             )
-        return [cls(entry.bic) for entry in banks if entry.bic]
+        sorted_banks = sorted(
+            banks,
+            key=lambda b: b.primary,
+            reverse=True,
+        )
+        return [cls(entry.bic) for entry in sorted_banks if entry.bic]
 
     @classmethod
     def from_bank_code(cls, country_code: str, bank_code: str) -> BIC:
@@ -235,13 +236,13 @@ class BIC(common.Base):
                 # one with no branch code which is the most generic one.
                 generic_codes = [c for c in candidates if not c.branch_code]
                 if generic_codes:
-                    return sorted(generic_codes)[-1]
+                    return max(generic_codes)
 
                 # If we don't have one, we try to pick the one with
                 # 'XXX' as a branch code
                 generic_codes = [c for c in candidates if c.branch_code == "XXX"]
                 if generic_codes:
-                    return sorted(generic_codes)[-1]
+                    return max(generic_codes)
             return candidates[0]
         except (KeyError, IndexError) as e:
             raise exceptions.InvalidBankCode(
@@ -369,7 +370,7 @@ class BIC(common.Base):
             # entries per branch, so fall back to the institution's BIC when
             # the branch-specific lookup comes up empty.
             entries = registry.get_banks_by_bic(str(self)[:8])
-        return sorted({getattr(entry, key) for entry in entries if getattr(entry, key)})
+        return sorted({val for entry in entries if (val := getattr(entry, key))})
 
     @property
     def domestic_bank_codes(self) -> list[str]:

--- a/schwifty/checksum/__init__.py
+++ b/schwifty/checksum/__init__.py
@@ -13,10 +13,11 @@ from schwifty.domain import Component
 
 
 _alphabet: str = string.digits + string.ascii_uppercase
+_NUMERIFY_MAP: dict[str, str] = {c: str(i) for i, c in enumerate(_alphabet)}
 
 
 def numerify(value: str) -> int:
-    return int("".join(str(_alphabet.index(c)) for c in value))
+    return int("".join(_NUMERIFY_MAP[c] for c in value))
 
 
 def iso7064(
@@ -37,7 +38,7 @@ def weighted(
 
 
 def luhn(value: str) -> str:
-    numerical = "".join(str(_alphabet.index(n)) for n in value)
+    numerical = "".join(_NUMERIFY_MAP[n] for n in value)
     processed = "".join(str((2 - i % 2) * int(n)) for i, n in enumerate(reversed(numerical)))
     return str((10 - sum(int(n) for n in processed)) % 10)
 
@@ -52,7 +53,7 @@ class Algorithm(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def compute(self, components: list[str]) -> str:
-        return ""
+        pass
 
     def validate(self, components: list[str], expected: str) -> bool:
         return self.compute(components) == expected

--- a/schwifty/checksum/germany.py
+++ b/schwifty/checksum/germany.py
@@ -31,6 +31,10 @@ class Positions:
 
 
 def digit_sum(number: int) -> int:
+    if number < 10:
+        return number
+    if number < 100:
+        return number // 10 + number % 10
     return sum(int(d) for d in str(number))
 
 
@@ -43,7 +47,6 @@ class WeightedModulus(checksum.Algorithm):
     weights: ClassVar[list[int]]
 
     def __init__(self) -> None:
-        self.weighted_sum: int = 0
         self.remainder: int = 0
 
     @override
@@ -156,7 +159,7 @@ class Algorithm02(WeightedMod11):
         if self.remainder == 0:
             return 0
         if self.remainder == 1:
-            raise InvalidBBANChecksum(f"Invalid remaidner: {self.remainder}")
+            raise InvalidBBANChecksum(f"Invalid remainder: {self.remainder}")
         return checksum
 
 
@@ -584,10 +587,8 @@ class Algorithm91(checksum.Algorithm):
 
     @override
     def validate(self, components: list[str], expected: str) -> bool:
-        for algo_cls in [self.Variant1, self.Variant2, self.Variant3, self.Variant4]:
-            if algo_cls().validate(components, expected):
-                return True
-        return False
+        variants = (self.Variant1, self.Variant2, self.Variant3, self.Variant4)
+        return any(algo_cls().validate(components, expected) for algo_cls in variants)
 
     @override
     def solve(self, components: list[str]) -> list[str] | None:

--- a/schwifty/checksum/italy.py
+++ b/schwifty/checksum/italy.py
@@ -6,15 +6,46 @@ from schwifty import checksum
 from schwifty._compat import override
 
 
+_CHAR_MAP: dict[str, int] = {
+    **{str(i): i for i in range(10)},
+    **{c: i for i, c in enumerate(string.ascii_uppercase)},
+    **{c: i for i, c in enumerate(string.ascii_lowercase)},
+}
+
+_ODDS: tuple[int, ...] = (
+    1,
+    0,
+    5,
+    7,
+    9,
+    13,
+    15,
+    17,
+    19,
+    21,
+    2,
+    4,
+    18,
+    20,
+    11,
+    3,
+    6,
+    8,
+    12,
+    14,
+    16,
+    10,
+    22,
+    25,
+    24,
+    23,
+)
+
+
 def get_index(char: str) -> int:
-    try:
-        return string.digits.index(char)
-    except ValueError:
-        return string.ascii_uppercase.index(char.upper())
+    return _CHAR_MAP[char]
 
 
-# Italy (IT)
-# San Marino (SM)
 @checksum.register("IT", "SM")
 class DefaultAlgorithm(checksum.Algorithm):
     name = "default"
@@ -22,16 +53,10 @@ class DefaultAlgorithm(checksum.Algorithm):
     @override
     def compute(self, components: list[str]) -> str:
         value = "".join(components)
-        odds = (
-            [1, 0, 5, 7, 9, 13, 15]  # noqa: RUF005
-            + [17, 19, 21, 2, 4, 18, 20]
-            + [11, 3, 6, 8, 12, 14, 16]
-            + [10, 22, 25, 24, 23]
-        )
         sum_ = 0
         for i, char in enumerate(value):
             if (i + 1) % 2 == 0:
                 sum_ += get_index(char)
             else:
-                sum_ += odds[get_index(char)]
+                sum_ += _ODDS[get_index(char)]
         return string.ascii_uppercase[sum_ % 26]

--- a/schwifty/checksum/norway.py
+++ b/schwifty/checksum/norway.py
@@ -22,11 +22,7 @@ class DefaultAlgorithm(checksum.Algorithm):
         value = account_code[2:] if account_code[:2] == "00" else "".join(components)
 
         weights = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2]
-        total: int = 0
-        for n, c in zip(weights, value, strict=False):
-            total += n * int(c)
-
-        check_digit = 11 - (total % 11)
+        check_digit = 11 - checksum.weighted(value, 11, weights)
         if check_digit == 10:
             raise InvalidAccountCode("Check digit does not compute: Invalid account code.")
         return str(check_digit % 11)

--- a/schwifty/common.py
+++ b/schwifty/common.py
@@ -45,7 +45,7 @@ class Base(str):
 
     def _get_slice(self, start: int, end: int | None = None) -> str:
         if start < len(self) and (end is None or end <= len(self)):
-            return self.compact[start:end] if end is not None else self.compact[start:]
+            return self[start:end]
         return ""
 
 

--- a/schwifty/exceptions.py
+++ b/schwifty/exceptions.py
@@ -3,11 +3,11 @@ class SchwiftyException(ValueError):  # noqa: N818
 
 
 class InvalidLength(SchwiftyException):
-    """Indicates that the length of the input does not match the specifcation."""
+    """Indicates that the length of the input does not match the specification."""
 
 
 class InvalidStructure(SchwiftyException):
-    """Indicates a strctural error of the input (e.g. invalid characters)."""
+    """Indicates a structural error of the input (e.g. invalid characters)."""
 
 
 class InvalidCountryCode(SchwiftyException):
@@ -19,11 +19,11 @@ class InvalidBankCode(SchwiftyException):
 
 
 class InvalidBranchCode(SchwiftyException):
-    """Indicates that the branch code has an invalid strucutre."""
+    """Indicates that the branch code has an invalid structure."""
 
 
 class InvalidAccountCode(SchwiftyException):
-    """Indicates that the account code has an invalid strucutre."""
+    """Indicates that the account code has an invalid structure."""
 
 
 class InvalidChecksumDigits(SchwiftyException):

--- a/schwifty/iban.py
+++ b/schwifty/iban.py
@@ -19,6 +19,10 @@ from schwifty.domain import Bank
 from schwifty.domain import IBANSpec
 
 
+_IBAN_STRUCTURE_RE = re.compile(r"[A-Z]{2}\d{2}[A-Z0-9]+")
+_iso7064_mod97_10 = ISO7064_mod97_10()
+
+
 if TYPE_CHECKING:
     from pydantic import GetCoreSchemaHandler
     from pydantic import GetJsonSchemaHandler
@@ -99,9 +103,8 @@ class IBAN(common.Base):
 
         .. versionadded:: 2024.01.2
         """
-        checksum_algo = ISO7064_mod97_10()
         return cls(
-            country_code + checksum_algo.compute([bban, country_code]) + bban,
+            country_code + _iso7064_mod97_10.compute([bban, country_code]) + bban,
             allow_invalid=allow_invalid,
             validate_bban=validate_bban,
         )
@@ -229,7 +232,7 @@ class IBAN(common.Base):
         # digits that appear in most BBANs, so invalid characters after the
         # country/check-digit prefix slipped through. ``fullmatch`` over the
         # alphanumeric BBAN catches them.
-        if not re.fullmatch(r"[A-Z]{2}\d{2}[A-Z0-9]+", self):
+        if not _IBAN_STRUCTURE_RE.fullmatch(self):
             raise exceptions.InvalidStructure(f"Invalid characters in IBAN {self!s}")
 
     def _validate_length(self) -> None:
@@ -248,8 +251,7 @@ class IBAN(common.Base):
         # check digits in the range 02..98, whereas the raw mod-97 test additionally accepts the
         # aliases 00, 01 and 99 (which no genuine IBAN carries). A passing ``validate`` always
         # implies ``self.numeric % 97 == 1``, so the latter check is redundant.
-        checksum_algo = ISO7064_mod97_10()
-        if not checksum_algo.validate([self.bban, self.country_code], self.checksum_digits):
+        if not _iso7064_mod97_10.validate([self.bban, self.country_code], self.checksum_digits):
             raise exceptions.InvalidChecksumDigits("Invalid checksum digits")
 
     @property

--- a/schwifty/registry.py
+++ b/schwifty/registry.py
@@ -38,7 +38,7 @@ def convert_bban_spec_to_regex(spec: str) -> str:
     return rf"^{re.sub(spec_re, convert, spec)}$"
 
 
-def add_bban_regex(country: str, spec: dict[str, Any]) -> dict[str, Any]:
+def add_bban_regex(spec: dict[str, Any]) -> dict[str, Any]:
     if "regex" not in spec:
         spec["regex"] = re.compile(convert_bban_spec_to_regex(spec["bban_spec"]))
     return spec
@@ -46,7 +46,7 @@ def add_bban_regex(country: str, spec: dict[str, Any]) -> dict[str, Any]:
 
 def merge_dicts(left: dict[Key, Any], right: dict[Key, Any]) -> dict[Key, Any]:
     merged = {}
-    for key in frozenset(right) & frozenset(left):
+    for key in left.keys() & right:
         left_value, right_value = left[key], right[key]
         if isinstance(left_value, dict) and isinstance(right_value, dict):
             merged[key] = merge_dicts(left_value, right_value)
@@ -123,7 +123,7 @@ class Registry:
             assert isinstance(data, dict)
             for country, spec in data.items():
                 assert isinstance(country, str)
-                data[country] = add_bban_regex(country, spec)
+                data[country] = add_bban_regex(spec)
 
         return self._save(name, data)
 
@@ -178,7 +178,7 @@ class Registry:
             defaults=defaults,
         )
 
-    def _parse_bank(self, data: dict[Key, Any]) -> Bank:
+    def _parse_bank(self, data: dict[Key, Any] | Bank) -> Bank:
         if isinstance(data, Bank):
             return data
         return Bank(
@@ -192,29 +192,21 @@ class Registry:
         )
 
     def get_banks_by_country(self, country_code: str) -> list[Bank]:
-        if not self._has("country"):
-            self._build_country_index()
         country_index = self._get("country")
         assert isinstance(country_index, dict)
         return country_index.get(country_code, [])
 
     def get_banks_by_code(self, country_code: str, bank_code: str) -> list[Bank]:
-        if not self._has("bank_code"):
-            self._build_bank_code_index()
         bank_code_index = self._get("bank_code")
         assert isinstance(bank_code_index, dict)
         return bank_code_index.get((country_code, bank_code), [])
 
     def get_banks_by_bic(self, bic: str) -> list[Bank]:
-        if not self._has("bic"):
-            self._build_bic_index()
         bic_index = self._get("bic")
         assert isinstance(bic_index, dict)
         return bic_index.get(bic, [])
 
     def get_countries(self) -> list[str]:
-        if not self._has("country"):
-            self._build_country_index()
         country_index = self._get("country")
         assert isinstance(country_index, dict)
         return [str(k) for k in country_index]
@@ -227,7 +219,7 @@ class Registry:
     def _build_country_index(self) -> None:
         base = self._get("bank")
         assert isinstance(base, list)
-        data = defaultdict(list)
+        data: dict[Key, list[Bank]] = defaultdict(list)
         for entry in base:
             assert isinstance(entry, dict)
             country_code = entry.get("country_code")
@@ -238,7 +230,7 @@ class Registry:
     def _build_bank_code_index(self) -> None:
         base = self._get("bank")
         assert isinstance(base, list)
-        data = defaultdict(list)
+        data: dict[Key, list[Bank]] = defaultdict(list)
         for entry in base:
             assert isinstance(entry, dict)
             country_code = entry.get("country_code")
@@ -250,7 +242,7 @@ class Registry:
     def _build_bic_index(self) -> None:
         base = self._get("bank")
         assert isinstance(base, list)
-        data = defaultdict(list)
+        data: dict[Key, list[Bank]] = defaultdict(list)
         for entry in base:
             assert isinstance(entry, dict)
             bic = entry.get("bic")


### PR DESCRIPTION
- Precompute static lookup maps and singletons in checksum and IBAN modules.
- Reuse existing checksum.weighted() helper in Norway checksum algorithm.
- Extract _bank_lookup_key helper property in BBAN to avoid duplicate component construction.
- Optimize candidate sorting and branch code resolution in BIC.
- Remove redundant index build guards and dead country parameter in registry.
- Optimize digit_sum arithmetic and simplify Algorithm91 validation in Germany checksum.
- Fix typographical errors in exception docstrings and messages.
- Update changelog with internal improvements note.