### PR TITLE
fix: preserve allow_invalid when deep-copying IBAN and BIC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Versions follow `CalVer <http://www.calver.org/>`_ with the scheme ``YY.0M.Micro
 
 Unreleased
 ----------
+Fixed
+~~~~~
+* Deep-copying an IBAN or BIC created with ``allow_invalid=True`` no longer raises a
+  validation error. The copy preserves the original value and validation status.
+
 Added
 ~~~~~
 * Added e-money institutions and banks that were missing from the bank registries: OpenPayd

--- a/schwifty/common.py
+++ b/schwifty/common.py
@@ -31,7 +31,7 @@ class Base(str):
         return str(self) < str(other)
 
     def __deepcopy__(self, memo: dict[str, Any] | None = None) -> Self:
-        return self.__class__(str(self))
+        return self.__class__(str(self), allow_invalid=True)
 
     @property
     def compact(self) -> str:

--- a/tests/test_bic.py
+++ b/tests/test_bic.py
@@ -320,3 +320,15 @@ def test_deepcopy() -> None:
     bic_copy = copy.copy(bic)
     assert id(bic) != id(bic_copy)
     assert bic == bic_copy
+
+
+@pytest.mark.parametrize("value", ["GENODXM1GLS", "FOOBARBAZ"])
+def test_deepcopy_allow_invalid(value: str) -> None:
+    original = BIC(value, allow_invalid=True)
+
+    copied = copy.deepcopy(original)
+
+    assert copied is not original
+    assert isinstance(copied, BIC)
+    assert copied == original
+    assert not copied.is_valid

--- a/tests/test_iban.py
+++ b/tests/test_iban.py
@@ -527,3 +527,15 @@ def test_copy() -> None:
     iban_copy = copy.copy(iban)
     assert id(iban) != id(iban_copy)
     assert iban == iban_copy
+
+
+@pytest.mark.parametrize("value", ["DE99 3704 0044 0532 0130 00", "XX89 3704 0044 0532 0130 00"])
+def test_deepcopy_allow_invalid(value: str) -> None:
+    original = IBAN(value, allow_invalid=True)
+
+    copied = copy.deepcopy(original)
+
+    assert copied is not original
+    assert isinstance(copied, IBAN)
+    assert copied == original
+    assert not copied.is_valid


### PR DESCRIPTION
## Problem

`Base.__deepcopy__` rebuilds the object through the validating constructor. An `IBAN` or `BIC` created with `allow_invalid=True` therefore raises as soon as it is deep-copied, which happens implicitly for dataclasses, pydantic models or any container holding such a value:

```python
iban = IBAN("DE99 3704 0044 0532 0130 00", allow_invalid=True)
copy.deepcopy(iban)  # InvalidChecksumDigits
```

## Fix

Construct the copy with `allow_invalid=True`. Valid objects are unaffected; invalid ones keep their value and `is_valid` status. Added a CHANGELOG entry under Unreleased/Fixed.

## Tests

- Added `test_deepcopy_allow_invalid` for both `IBAN` (bad checksum, unknown country) and `BIC` (unknown bank, invalid length). All four cases failed before the change.
- `uv run poe check` and `uv run poe test` (427 passed) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtpcFAThUxrGAyCyxiiEC5
